### PR TITLE
Small change to make ashley compatible with JDK 1.6

### DIFF
--- a/ashley/.settings/org.eclipse.jdt.core.prefs
+++ b/ashley/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,11 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.source=1.6

--- a/ashley/src/ashley/core/Entity.java
+++ b/ashley/src/ashley/core/Entity.java
@@ -44,8 +44,8 @@ public class Entity {
 		
 		index = nextIndex++;
 		
-		componentAdded = new Signal<>();
-		componentRemoved = new Signal<>();
+		componentAdded = new Signal<Entity>();
+		componentRemoved = new Signal<Entity>();
 	}
 	
 	/**


### PR DESCRIPTION
I'm currently testing your entity framework on my Libgdx game (no more ComponentMappers!). I need this small change to be able to run the Android version.
