### PR TITLE
Bugs found on Component removal

### DIFF
--- a/ashley/src/ashley/core/Engine.java
+++ b/ashley/src/ashley/core/Engine.java
@@ -167,7 +167,7 @@ public class Engine {
 			if(entity.getFamilyBits().get(entry.key.getFamilyIndex())){
 				if(!entry.key.matches(entity)){
 					entry.value.remove(entity.getIndex());
-					entity.getFamilyBits().set(entry.key.getFamilyIndex());
+					entity.getFamilyBits().clear(entry.key.getFamilyIndex());
 				}
 			}
 		}

--- a/ashley/src/ashley/core/Entity.java
+++ b/ashley/src/ashley/core/Entity.java
@@ -72,6 +72,8 @@ public class Entity {
 		Component removeComponent = components.get(componentType, null);
 		
 		if(removeComponent != null){
+			components.remove(componentType);
+
 			componentBits.clear(ComponentType.getIndexFor(componentType));
 			
 			componentRemoved.dispatch(this);


### PR DESCRIPTION
Hi! I'm really really loving your entity aproach, but using it on my game prototype I've found (and solved, I think) a pair of bugs when removing and adding later the same component:

On Entity.java, the component wasn't removed, just the componentBits was
cleared.

On Engine.java, when the component removal signal was dispatched, the
familyBits was set, not cleared
