### PR TITLE
Use Gwt safe casts and ClassReflection methods

### DIFF
--- a/core/src/com/badlogic/ashley/core/Engine.java
+++ b/core/src/com/badlogic/ashley/core/Engine.java
@@ -190,7 +190,7 @@ public class Engine {
 	 * @return The Entity System
 	 */
 	public <T extends EntitySystem> T getSystem(Class<T> systemType) {
-		return systemType.cast(systemsByClass.get(systemType));
+		return (T) systemsByClass.get(systemType);
 	}
 	
 	/**

--- a/core/src/com/badlogic/ashley/core/Entity.java
+++ b/core/src/com/badlogic/ashley/core/Entity.java
@@ -139,7 +139,7 @@ public class Entity {
 	 * @return The Component
 	 */
 	public <T extends Component> T getComponent(Class<T> componentType){
-		return componentType.cast(components.get(componentType));
+		return (T) components.get(componentType);
 	}
 	
 	/**

--- a/core/src/com/badlogic/ashley/core/Family.java
+++ b/core/src/com/badlogic/ashley/core/Family.java
@@ -107,7 +107,6 @@ public class Family {
 	 * @param exclude entities cannot contain any of the components in the set. See {@link ComponentType#getBitsFor(Class<? extends Component> ...)}.
 	 * @return The family
 	 */
-	@SafeVarargs
 	public static Family getFamilyFor(Bits all, Bits one, Bits exclude){
 		String hash = getFamilyHash(all, one, exclude);
 		Family family = families.get(hash, null);

--- a/core/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/core/src/com/badlogic/ashley/core/PooledEngine.java
@@ -19,6 +19,7 @@ package com.badlogic.ashley.core;
 import com.badlogic.gdx.utils.Pool;
 import com.badlogic.gdx.utils.Pool.Poolable;
 import com.badlogic.gdx.utils.Pools;
+import com.badlogic.gdx.utils.reflect.ClassReflection;
 
 
 /**
@@ -59,8 +60,8 @@ public class PooledEngine extends Engine {
 	public void removeEntity(Entity entity){
 		super.removeEntity(entity);
 		
-		if (PooledEntity.class.isAssignableFrom(entity.getClass())) {
-			PooledEntity pooledEntity = PooledEntity.class.cast(entity);
+		if (ClassReflection.isAssignableFrom(PooledEntity.class, entity.getClass())) {
+			PooledEntity pooledEntity = (PooledEntity) entity;
 			entityPool.free(pooledEntity);
 		}
 	}


### PR DESCRIPTION
This should fix up the Gwt woes.
- Removes uneeded @varargs annotation
- Removes gwt-unfriendly class.cast methods (replaces with almost redundant (T) cast
- Use Gdx's ClassReflection class.

Tested with RenderSystemTest
