### PR TITLE
Allows adding/not adding an Entity by an EntityListener

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -95,24 +95,29 @@ public class Engine {
 	 * Adds an entity to this Engine.
 	 */
 	public void addEntity(Entity entity){
-		entities.add(entity);
-		
-		for (Entry<Family, Array<Entity>> entry : families.entries()) {
-			if(entry.key.matches(entity)){
-				entry.value.add(entity);
-				entity.getFamilyBits().set(entry.key.getIndex());
-			}
-		}
-		
-		entity.componentAdded.add(componentAdded);
-		entity.componentRemoved.add(componentRemoved);
+		boolean shouldadd = true;
 		
 		notifying = true;
 		for (EntityListener listener : listeners) {
-			listener.entityAdded(entity);
+			if(shouldadd) shouldadd = listener.entityAdded(entity);
+			else listener.entityAdded(entity);
 		}
 		notifying = false;
 		removePendingListeners();
+		
+		if(shouldadd){
+			entities.add(entity);
+			
+			for (Entry<Family, Array<Entity>> entry : families.entries()) {
+				if(entry.key.matches(entity)){
+					entry.value.add(entity);
+					entity.getFamilyBits().set(entry.key.getIndex());
+				}
+			}
+			
+			entity.componentAdded.add(componentAdded);
+			entity.componentRemoved.add(componentRemoved);
+		}
 	}
 	
 	/**

--- a/ashley/src/com/badlogic/ashley/core/EntityListener.java
+++ b/ashley/src/com/badlogic/ashley/core/EntityListener.java
@@ -26,8 +26,10 @@ public interface EntityListener {
 	 * Called whenever an {@link Entity} is added to {@link Engine}
 	 * 
 	 * @param entity
+	 * @return The {@link Entity} gets not added to {@link Engine} if one {@link EntityListener} returns false
+	 *  
 	 */
-	public void entityAdded(Entity entity);
+	public boolean entityAdded(Entity entity);
 	
 	/**
 	 * Called whenever an {@link Entity} is removed from {@link Engine}

--- a/ashley/tests/com/badlogic/ashley/core/EngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EngineTests.java
@@ -46,9 +46,10 @@ public class EngineTests {
 		public int removedCount = 0;
 		
 		@Override
-		public void entityAdded(Entity entity) {
+		public boolean entityAdded(Entity entity) {
 			++addedCount;
 			assertNotNull(entity);
+			return true;
 		}
 
 		@Override

--- a/tests/src/com/badlogic/ashley/tests/BasicTest.java
+++ b/tests/src/com/badlogic/ashley/tests/BasicTest.java
@@ -117,8 +117,9 @@ public class BasicTest {
 	public static class Listener implements EntityListener {
 
 		@Override
-		public void entityAdded(Entity entity) {
+		public boolean entityAdded(Entity entity) {
 			log("Entity added " + entity);
+			return true;
 		}
 
 		@Override


### PR DESCRIPTION
EntityListener.entityAdded(Entity) is a boolean witch the implementation can use to use to allow adding an Entity to the Engine.
