### PR TITLE
Increment index of pooled entities

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Entity.java
+++ b/ashley/src/com/badlogic/ashley/core/Entity.java
@@ -77,6 +77,14 @@ public class Entity {
 	public int getIndex(){
 		return index;
 	}
+
+
+	/**
+	 * Reset the index 
+	 */
+	public void resetIndex() {
+		index =  nextIndex++;
+	}
 	
 	/**
 	 * Adds a {@link Component} to this Entity. If a {@link Component} of the same type already exists, it'll be replaced.

--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -115,6 +115,7 @@ public class PooledEngine extends Engine {
 		public void reset() {
 			removeAll();
 			flags = 0;
+			resetIndex();
 		}
 	}
 	


### PR DESCRIPTION
Re-using indexes in pooled entities gave me serious problems when trying to transmit entities over network. It was lot easier by having unique indexes. 

I do increment in the reset() function because If I do it in the obtain() part, the first entity index will be set to 1 instead of 0.
