### PR TITLE
Fixes crash when trying to remove an invalid component from a PooledEntity #77

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -106,7 +106,11 @@ public class PooledEngine extends Engine {
 		@Override
 		Component removeInternal(Class<? extends Component> componentType){
 			Component component = super.removeInternal(componentType);
-			componentPools.free(component);
+			
+			if(component != null) {
+				componentPools.free(component);
+			}
+			
 			return component;
 		}
 


### PR DESCRIPTION
Adds a really simple null check.
