### PR TITLE
Fix javadoc bug for java version prior to 8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,11 @@ ext {
 }
 
 /** needed to disable Java 8 doclint which throws errors **/
-allprojects {
-    tasks.withType(Javadoc) {
-        options.addStringOption('Xdoclint:none', '-quiet')
+if (JavaVersion.current().isJava8Compatible()) {
+    allprojects {
+	tasks.withType(Javadoc) {
+	    options.addStringOption('Xdoclint:none', '-quiet')
+	}
     }
 }
 


### PR DESCRIPTION
This option is unsuported with javadoc compiler prior to 8 and make the task failed.
