### PR TITLE
Entity.hashcode compatible to java versions prior to 8.

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Entity.java
+++ b/ashley/src/com/badlogic/ashley/core/Entity.java
@@ -223,7 +223,7 @@ public class Entity {
 	
 	@Override
 	public int hashCode() {
-		return Long.hashCode(uuid);
+		return (int)(uuid ^ (uuid >>> 32));
 	}
 
 	@Override


### PR DESCRIPTION
#88 was using code introduced in Java8.
