### PR TITLE
Fixed the Array creation when registering a new Family. Before the Arrays were created as Object Array...

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -357,7 +357,7 @@ public class Engine {
 		ImmutableArray<Entity> immutableEntities = immutableFamilies.get(family);
 		
 		if (immutableEntities == null) {
-			Array<Entity> entities = new Array<Entity>(false, 16);
+			Array<Entity> entities = new Array<Entity>(false, 16, Entity.class);
 			immutableEntities = new ImmutableArray<Entity>(entities);
 			families.put(family, entities);
 			immutableFamilies.put(family, immutableEntities);


### PR DESCRIPTION
...s and I had problems when casting them later on. Now the Arrays are created as Arrays of Entities.
