### PR TITLE
Marking entities about to be removed, avoiding multiple removal

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -125,6 +125,10 @@ public class Engine {
 	 */
 	public void removeEntity(Entity entity){
 		if (updating || notifying) {
+			if(entity.scheduledForRemoval) {
+				return;
+			}
+			entity.scheduledForRemoval = true;
 			EntityOperation operation = entityOperationPool.obtain();
 			operation.entity = entity;
 			operation.type = EntityOperation.Type.Remove;
@@ -273,6 +277,7 @@ public class Engine {
 	}
 	
 	protected void removeEntityInternal(Entity entity) {
+		entity.scheduledForRemoval = false;
 		entities.removeValue(entity, true);
 		
 		if(!entity.getFamilyBits().isEmpty()){

--- a/ashley/src/com/badlogic/ashley/core/Entity.java
+++ b/ashley/src/com/badlogic/ashley/core/Entity.java
@@ -51,6 +51,7 @@ public class Entity {
 	private Bits componentBits;
 	/** A Bits describing all the systems this entity was matched with. */
 	private Bits familyBits;
+	boolean scheduledForRemoval;
 	
 	ComponentOperationHandler componentOperationHandler;
 	
@@ -238,5 +239,12 @@ public class Entity {
 	
 	static long obtainId() {
 		return nextId++;
+	}
+
+	/**
+	 * @return true if the entity is scheduled to be removed
+	 */
+	public boolean isScheduledForRemoval() {
+		return scheduledForRemoval;
 	}
 }

--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -119,6 +119,7 @@ public class PooledEngine extends Engine {
 			flags = 0;
 			componentAdded.removeAllListeners();
 			componentRemoved.removeAllListeners();
+			scheduledForRemoval = false;
 		}
 	}
 	


### PR DESCRIPTION
I've had some weird behavior, as some of my entities got removed multiple times at times.
This code helps to avoid this. I guess you could do this from the users code with flags, but it seems such a basic feature.
