### PR TITLE
Complementary maven POM (Not suggesting replacing gradle with maven)

### DIFF
--- a/ashley/.gitignore
+++ b/ashley/.gitignore
@@ -1,1 +1,2 @@
 /build
+target/

--- a/ashley/pom.xml
+++ b/ashley/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.badlogic.ashley</groupId>
+	<artifactId>ashley</artifactId>
+	<version>1.3.2-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>Ashley Entity System</name>
+	
+	<dependencies>
+		<dependency>
+			<groupId>com.badlogicgames.gdx</groupId>
+			<artifactId>gdx</artifactId>
+			<version>1.3.1</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<sourceDirectory>${project.basedir}/src</sourceDirectory>
+		<testSourceDirectory>${project.basedir}/tests</testSourceDirectory>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.2</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>


### PR DESCRIPTION
Perhaps not needed, but I find it easier getting started with a project when there is a pom.xml to import or build from. Gradle and I have a troubled history; IDE:s tend to have better out-of-the-box support for maven too.
