### PR TITLE
Adding another EntityOperation RemoveAll. Fixes #101

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -143,8 +143,18 @@ public class Engine {
 	 * Removes all entities registered with this Engine.
 	 */
 	public void removeAllEntities() {
-		while(entities.size > 0) {
-			removeEntity(entities.first());
+		if (updating || notifying) {
+			for(Entity entity: entities) {
+				entity.scheduledForRemoval = true;
+			}
+			EntityOperation operation = entityOperationPool.obtain();
+			operation.type = EntityOperation.Type.RemoveAll;
+			entityOperations.add(operation);
+		}
+		else {
+			while(entities.size > 0) {
+				removeEntity(entities.first());
+			}
 		}
 	}
 	
@@ -385,6 +395,11 @@ public class Engine {
 			switch(operation.type) {
 				case Add: addEntityInternal(operation.entity); break;
 				case Remove: removeEntityInternal(operation.entity); break;
+				case RemoveAll:
+					while(entities.size > 0) {
+						removeEntityInternal(entities.first());
+					}
+					break;
 			}
 			
 			entityOperationPool.free(operation);
@@ -497,6 +512,7 @@ public class Engine {
 		public enum Type {
 			Add,
 			Remove,
+			RemoveAll
 		}
 		
 		public Type type;


### PR DESCRIPTION
If a lot of entities are used at the time removeAllEntities() is called, each will allocate an entity remove operation (during update/notifiy), causing lots of memory to be used.
