### PR TITLE
System categories for entity systems

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/SystemCategory.java
+++ b/ashley/src/com/badlogic/ashley/core/SystemCategory.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright 2014 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package com.badlogic.ashley.core;
+
+/**
+ * The system category is used to define a subset of systems. You can use this by creating an enum (or a class if you
+ * prefer) that implements this interface. You can then add a system to the {@link Engine} by using the category you
+ * define.
+ * @author Andrew Fischer
+ */
+public interface SystemCategory {
+}

--- a/ashley/tests/com/badlogic/ashley/core/EngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EngineTests.java
@@ -16,13 +16,11 @@
 
 package com.badlogic.ashley.core;
 
-import static org.junit.Assert.*;
-
-import org.junit.Test;
-
 import com.badlogic.ashley.utils.ImmutableArray;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.Bits;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 @SuppressWarnings("unchecked")
 public class EngineTests {
@@ -201,6 +199,49 @@ public class EngineTests {
 		assertNull(engine.getSystem(EntitySystemMockB.class));
 		assertEquals(1, systemA.removedCalls);
 		assertEquals(1, systemB.removedCalls);
+	}
+
+	private static enum TestSystemCategory implements SystemCategory {
+		TEST_CATEGORY_1,
+		TEST_CATEGORY_2,
+		TEST_CATEGORY_3
+	}
+
+	@Test
+	public void addAndRemoveSystemByCategory() {
+		Engine engine = new Engine();
+		EntitySystemMockA systemA = new EntitySystemMockA();
+		EntitySystemMockB systemB = new EntitySystemMockB();
+
+		assertNull(engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_1));
+		assertNull(engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_2));
+
+		engine.addSystemByCategory(TestSystemCategory.TEST_CATEGORY_1, systemA);
+		engine.addSystemByCategory(TestSystemCategory.TEST_CATEGORY_2, systemB);
+
+		assertNotNull(engine.getSystem(EntitySystemMockA.class));
+		assertNotNull(engine.getSystem(EntitySystemMockB.class));
+		assertNotNull(engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_1));
+		assertNotNull(engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_2));
+
+		assertNull(engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_3));
+
+		assertEquals(1, engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_1).size);
+		assertEquals(1, engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_2).size);
+		assertEquals(1, systemA.addedCalls);
+		assertEquals(1, systemB.addedCalls);
+		assertEquals(2, engine.getSystems().size());
+
+		engine.removeSystem(systemA);
+		assertEquals(0, engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_1).size);
+		engine.removeSystem(systemB);
+		assertEquals(0, engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_2).size);
+
+		assertEquals(0, engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_1).size);
+		assertEquals(0, engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_2).size);
+		assertEquals(1, systemA.removedCalls);
+		assertEquals(1, systemB.removedCalls);
+		assertEquals(0, engine.getSystems().size());
 	}
 
 	@Test

--- a/ashley/tests/com/badlogic/ashley/core/EngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EngineTests.java
@@ -233,9 +233,7 @@ public class EngineTests {
 		assertEquals(2, engine.getSystems().size());
 
 		engine.removeSystem(systemA);
-		assertEquals(0, engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_1).size);
 		engine.removeSystem(systemB);
-		assertEquals(0, engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_2).size);
 
 		assertEquals(0, engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_1).size);
 		assertEquals(0, engine.getSystemsByCategory(TestSystemCategory.TEST_CATEGORY_2).size);


### PR DESCRIPTION
When working on a game using libgdx/ashley together, I ran into some issues where I needed to update separate groups of entities in a different order with logic in between. I didn't want to call getSystem() for every single system I had and iterating getSystems() isn't any better since I'd have to use reflection or something to try to see what it is. I wasn't able to do this while also manually overriding update(). It hides the updating boolean along with some other functions so I was unable to call them properly. I decided to attempt to modify the code a little bit in order to allow custom groups, along with making the update call a little more flexible.

If anyone thinks this is good enough to be merged in, that's great. I'm open to ways of making this better. I'm not entirely convinced making SystemCategory an interface to extend was the best way to go about it, but it was all I could think of at the time. Not really a fan of using plain old strings, but that's another option. Maybe there's a totally different way that's better.