### PR TITLE
Add @SafeVarargs to new Family methods.

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Family.java
+++ b/ashley/src/com/badlogic/ashley/core/Family.java
@@ -110,6 +110,7 @@ public class Family {
 	 * @param componentTypes entities will have to contain all of the specified components.
 	 * @return A Builder singleton instance to get a family
 	 */
+	@SafeVarargs
 	public static Builder all (Class<? extends Component>... componentTypes) {
 		return builder.reset().all(componentTypes);
 	}
@@ -118,6 +119,7 @@ public class Family {
 	 * @param componentTypes entities will have to contain at least one of the specified components.
 	 * @return A Builder singleton instance to get a family
 	 */
+	@SafeVarargs
 	public static Builder one (Class<? extends Component>... componentTypes) {
 		return builder.reset().one(componentTypes);
 	}
@@ -126,6 +128,7 @@ public class Family {
 	 * @param componentTypes entities cannot contain any of the specified components.
 	 * @return A Builder singleton instance to get a family
 	 */
+	@SafeVarargs
 	public static Builder exclude (Class<? extends Component>... componentTypes) {
 		return builder.reset().exclude(componentTypes);
 	}
@@ -150,6 +153,7 @@ public class Family {
 		 * @param componentTypes entities will have to contain all of the specified components.
 		 * @return A Builder singleton instance to get a family
 		 */
+		@SafeVarargs
 		public Builder all (Class<? extends Component>... componentTypes) {
 			all = ComponentType.getBitsFor(componentTypes);
 			return this;
@@ -159,6 +163,7 @@ public class Family {
 		 * @param componentTypes entities will have to contain at least one of the specified components.
 		 * @return A Builder singleton instance to get a family
 		 */
+		@SafeVarargs
 		public Builder one (Class<? extends Component>... componentTypes) {
 			one = ComponentType.getBitsFor(componentTypes);
 			return this;
@@ -168,6 +173,7 @@ public class Family {
 		 * @param componentTypes entities cannot contain any of the specified components.
 		 * @return A Builder singleton instance to get a family
 		 */
+		@SafeVarargs
 		public Builder exclude (Class<? extends Component>... componentTypes) {
 			exclude = ComponentType.getBitsFor(componentTypes);
 			return this;


### PR DESCRIPTION
This removes the need for suppressing warnings in user code.
