### PR TITLE
Pooling with reset for ComponentOperation & EntityOperation

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -476,7 +476,7 @@ public class Engine {
 		}
 	}
 	
-	private static class ComponentOperation {
+	private static class ComponentOperation implements Pool.Poolable {
 		public enum Type {
 			Add,
 			Remove,
@@ -500,7 +500,13 @@ public class Engine {
 			this.component = null;
 			this.componentClass = componentClass;
 		}
-	}
+
+        @Override
+        public void reset() {
+            entity = null;
+            component = null;
+        }
+    }
 	
 	private static class ComponentOperationPool extends Pool<ComponentOperation> {
 		@Override
@@ -516,7 +522,7 @@ public class Engine {
 		}
 	}
 	
-	private static class EntityOperation {
+	private static class EntityOperation implements Pool.Poolable {
 		public enum Type {
 			Add,
 			Remove,
@@ -525,7 +531,12 @@ public class Engine {
 		
 		public Type type;
 		public Entity entity;
-	}
+
+        @Override
+        public void reset() {
+            entity = null;
+        }
+    }
 	
 	private static class EntityOperationPool extends Pool<EntityOperation> {
 		@Override

--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -500,13 +500,7 @@ public class Engine {
 			this.component = null;
 			this.componentClass = componentClass;
 		}
-
-        @Override
-        public void reset() {
-            entity = null;
-            component = null;
-        }
-    }
+	}
 	
 	private static class ComponentOperationPool extends Pool<ComponentOperation> {
 		@Override
@@ -531,12 +525,7 @@ public class Engine {
 		
 		public Type type;
 		public Entity entity;
-
-        @Override
-        public void reset() {
-            entity = null;
-        }
-    }
+	}
 	
 	private static class EntityOperationPool extends Pool<EntityOperation> {
 		@Override

--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -500,6 +500,12 @@ public class Engine {
 			this.component = null;
 			this.componentClass = componentClass;
 		}
+
+		@Override
+		public void reset() {
+			entity = null;
+			component = null;
+		}
 	}
 	
 	private static class ComponentOperationPool extends Pool<ComponentOperation> {
@@ -525,6 +531,11 @@ public class Engine {
 		
 		public Type type;
 		public Entity entity;
+
+		@Override
+		public void reset() {
+			entity = null;
+		}
 	}
 	
 	private static class EntityOperationPool extends Pool<EntityOperation> {


### PR DESCRIPTION
`ComponentOperation` & `EntityOperation` participate as a poolable objects, but after been freed still keep references to entities and components. So I assume it's proper to reset them using `Pool.Poolable` interface.