### PR TITLE
Pooled Components obtained twice

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -87,12 +87,6 @@ public class PooledEngine extends Engine {
 		super.removeEntityInternal(entity);
 
 		if (entity instanceof PooledEntity) {
-			for (Component c : entity.getComponents()) {
-				if (c instanceof Poolable) {
-					componentPools.free(c);
-				}
-			}
-			
 			entityPool.free((PooledEntity)entity);
 		}
 	}


### PR DESCRIPTION
The world.createComponent() method always returned twice the very same component because they were added twice on the freeObjects pool for every pooled component removed: once on the deleted loop, and another time when you do entityPool.free((PooledEntity)entity) on the next line after the removed loop (entityPool.free->reset->removeAll->removeInternal->componentPool.free)