### PR TITLE
Forcing sort in SortedIteratingSystem when removing entity fron unordered array

### DIFF
--- a/ashley/src/com/badlogic/ashley/systems/SortedIteratingSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/SortedIteratingSystem.java
@@ -107,6 +107,7 @@ public abstract class SortedIteratingSystem extends EntitySystem implements Enti
 	@Override
 	public void entityRemoved (Entity entity) {
 		sortedEntities.removeValue(entity, true);
+        shouldSort = true;
 	}
 
 	@Override


### PR DESCRIPTION
Using SortedIteratingSystem for rendering in my game I noticed that removing bullets from game completely randomize sort order.
Log from two SortedIteratingSystem updates one by one in which removing bullet breaks order (class name + z order used to sort):

```
START SortedIteratingSystem UPDATE
class com.infunity.game.entity.Bullet -10.0 
class com.infunity.game.entity.Player 10.0 
class com.infunity.game.entity.Gun 20.0 
STOP SortedIteratingSystem UPDATE
START  SortedIteratingSystem UPDATE
class com.infunity.game.entity.Gun 20.0 
class com.infunity.game.entity.Player 10.0 
STOP SortedIteratingSystem UPDATE
```

I found out that SortedIteratingSystem use unordered array: `sortedEntities = new Array<Entity>(false, 16);`
```
/** @param ordered If false, methods that remove elements may change the order of other elements in the array, which avoids a
 *           memory copy.
 * @param capacity Any elements added beyond this will cause the backing array to be grown. */
public Array (boolean ordered, int capacity) {
	this.ordered = ordered;
	items = (T[])new Object[capacity];
}
```

Considering that SortedIteratingSystem should force sorting when entity is removed.