### PR TITLE
Multiple entity removal inside PooledEngine

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -84,6 +84,9 @@ public class PooledEngine extends Engine {
 
 	@Override
 	protected void removeEntityInternal (Entity entity) {
+        // Check if entity is able to be removed (id == 0 means either entity is not used by engine, or already removed/in pool)
+        if (entity.getId() == 0) return;
+
 		super.removeEntityInternal(entity);
 
 		if (entity instanceof PooledEntity) {

--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -84,8 +84,8 @@ public class PooledEngine extends Engine {
 
 	@Override
 	protected void removeEntityInternal (Entity entity) {
-        // Check if entity is able to be removed (id == 0 means either entity is not used by engine, or already removed/in pool)
-        if (entity.getId() == 0) return;
+		// Check if entity is able to be removed (id == 0 means either entity is not used by engine, or already removed/in pool)
+		if (entity.getId() == 0) return;
 
 		super.removeEntityInternal(entity);
 


### PR DESCRIPTION
Hey guys,
Today I start rewriting my game from regular `Engine` to `PooledEngine` and have faced with an interesting bug.
Assume we have some `PooledEntity` inside `PooledEngine` and in some moment next code occurs during update:
```
engine.removeEntity(entity);
engine.removeAllEntities();
```

Now engine creates two operations to schedule removal (one of `Remove` type and another of `RemoveAll`). Then engine starts to execute operations inside `processPendingEntityOperations()`. Operation `RemoveAll` goes first, it removes our entity and place it inside entity pool. Then performs `Remove` operation, which has no idea about fact, that entity has been already removed and calls `removeEntityInternal(entity)` in a second time. And now we've got entity pool with same two items, which means next two calls to `PooledEngine#createEntity()` will give us same instance of `PooledEntity`.

My solution is to check whether entity already been removed or not by `entity.getId() == 0` right before code of `removeEntityInternal(entity)` will be executed.

Same things (multiple removes for same entity) may happen and in a regular `Engine` but there is no any pool or something that control entities, and it allow to outer code take control over their lifecycle and reuse them. So I think that check should have a place only inside `PooledEngine`.