### PR TITLE
Make update method of IntervalSystem to be final

### DIFF
--- a/ashley/src/com/badlogic/ashley/systems/IntervalSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/IntervalSystem.java
@@ -45,7 +45,7 @@ public abstract class IntervalSystem extends EntitySystem {
 	}
 
 	@Override
-	public void update (float deltaTime) {
+	public final void update (float deltaTime) {
 		accumulator += deltaTime;
 
 		if (accumulator >= interval) {


### PR DESCRIPTION
This is a really minor change, but rather than just recommending people use updateInterval for the system's logic, this change allows the code to force it.