### PR TITLE
Fix various Family issues

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Family.java
+++ b/ashley/src/com/badlogic/ashley/core/Family.java
@@ -54,8 +54,8 @@ public class Family {
 	public boolean matches (Entity entity) {
 		Bits entityComponentBits = entity.getComponentBits();
 
-		for (int i = all.nextSetBit(0); i >= 0; i = all.nextSetBit(i + 1)) {
-			if (!entityComponentBits.get(i)) return false;
+		if (!entityComponentBits.containsAll(all)) {
+			return false;
 		}
 
 		if (!one.isEmpty() && !one.intersects(entityComponentBits)) {

--- a/ashley/src/com/badlogic/ashley/core/Family.java
+++ b/ashley/src/com/badlogic/ashley/core/Family.java
@@ -54,8 +54,6 @@ public class Family {
 	public boolean matches (Entity entity) {
 		Bits entityComponentBits = entity.getComponentBits();
 
-		if (entityComponentBits.isEmpty()) return false;
-
 		for (int i = all.nextSetBit(0); i >= 0; i = all.nextSetBit(i + 1)) {
 			if (!entityComponentBits.get(i)) return false;
 		}

--- a/ashley/src/com/badlogic/ashley/core/Family.java
+++ b/ashley/src/com/badlogic/ashley/core/Family.java
@@ -160,21 +160,12 @@ public class Family {
 
 	@Override
 	public int hashCode () {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + all.hashCode();
-		result = prime * result + one.hashCode();
-		result = prime * result + exclude.hashCode();
-		result = prime * result + index;
-		return result;
+		return index;
 	}
 
 	@Override
 	public boolean equals (Object obj) {
-		if (this == obj) return true;
-		if (!(obj instanceof Family)) return false;
-		Family other = (Family)obj;
-		return index == other.index && all.equals(other.all) && one.equals(other.one) && exclude.equals(other.exclude);
+		return this == obj;
 	}
 
 	private static String getFamilyHash (Bits all, Bits one, Bits exclude) {

--- a/ashley/tests/com/badlogic/ashley/core/FamilyTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/FamilyTests.java
@@ -68,6 +68,7 @@ public class FamilyTests {
 
 	@Test
 	public void validFamily () {
+		assertNotNull(Family.all().get());
 		assertNotNull(Family.all(ComponentA.class).get());
 		assertNotNull(Family.all(ComponentB.class).get());
 		assertNotNull(Family.all(ComponentC.class).get());
@@ -94,6 +95,8 @@ public class FamilyTests {
 			.exclude(ComponentE.class, ComponentF.class).get();
 		Family family8 = Family.all(ComponentA.class, ComponentB.class).one(ComponentC.class, ComponentD.class)
 			.exclude(ComponentE.class, ComponentF.class).get();
+		Family family9 = Family.all().get();
+		Family family10 = Family.all().get();
 
 		assertTrue(family1.equals(family2));
 		assertTrue(family2.equals(family1));
@@ -103,11 +106,13 @@ public class FamilyTests {
 		assertTrue(family6.equals(family5));
 		assertTrue(family7.equals(family8));
 		assertTrue(family8.equals(family7));
+		assertTrue(family9.equals(family10));
 
 		assertEquals(family1.getIndex(), family2.getIndex());
 		assertEquals(family3.getIndex(), family4.getIndex());
 		assertEquals(family5.getIndex(), family6.getIndex());
 		assertEquals(family7.getIndex(), family8.getIndex());
+		assertEquals(family9.getIndex(), family10.getIndex());
 	}
 
 	@Test
@@ -126,6 +131,7 @@ public class FamilyTests {
 			.exclude(ComponentE.class, ComponentF.class).get();
 		Family family12 = Family.all(ComponentC.class, ComponentD.class).one(ComponentE.class, ComponentF.class)
 			.exclude(ComponentA.class, ComponentB.class).get();
+		Family family13 = Family.all().get();
 
 		assertFalse(family1.equals(family2));
 		assertFalse(family1.equals(family3));
@@ -138,6 +144,7 @@ public class FamilyTests {
 		assertFalse(family1.equals(family10));
 		assertFalse(family1.equals(family11));
 		assertFalse(family1.equals(family12));
+		assertFalse(family1.equals(family13));
 
 		assertFalse(family10.equals(family1));
 		assertFalse(family10.equals(family2));
@@ -149,6 +156,7 @@ public class FamilyTests {
 		assertFalse(family10.equals(family8));
 		assertFalse(family10.equals(family9));
 		assertFalse(family11.equals(family12));
+		assertFalse(family10.equals(family13));
 
 		assertNotEquals(family1.getIndex(), family2.getIndex());
 		assertNotEquals(family1.getIndex(), family3.getIndex());
@@ -160,6 +168,7 @@ public class FamilyTests {
 		assertNotEquals(family1.getIndex(), family9.getIndex());
 		assertNotEquals(family1.getIndex(), family10.getIndex());
 		assertNotEquals(family11.getIndex(), family12.getIndex());
+		assertNotEquals(family1.getIndex(), family13.getIndex());
 	}
 
 	@Test
@@ -235,6 +244,13 @@ public class FamilyTests {
 
 		entity.add(new ComponentB());
 
+		assertTrue(family.matches(entity));
+	}
+
+	@Test
+	public void testEmptyFamily() {
+		Family family = Family.all().get();
+		Entity entity = new Entity();
 		assertTrue(family.matches(entity));
 	}
 


### PR DESCRIPTION
Currently, an empty family does not match an empty entity. This can be demonstrated with the following code snippet:
```java
Entity entity = new Entity();
Family family = Family.all().get();
System.out.println(family.matches(entity)); // false
```
This is certainly not the expected behaviour; it's caused by this strange check in Family.matches:
```java
if (entityComponentBits.isEmpty()) return false;
```
This pull request fixes that issue, and also simplifies the implementation of equals/hashCode for Family.