### PR TITLE
Expose the interval in IntervalSystem

### DIFF
--- a/ashley/src/com/badlogic/ashley/systems/IntervalSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/IntervalSystem.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2014 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -42,6 +42,10 @@ public abstract class IntervalSystem extends EntitySystem {
 		super(priority);
 		this.interval = interval;
 		this.accumulator = 0;
+	}
+
+	public float getInterval() {
+		return interval;
 	}
 
 	@Override

--- a/ashley/tests/com/badlogic/ashley/systems/IntervalSystemTest.java
+++ b/ashley/tests/com/badlogic/ashley/systems/IntervalSystemTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2014 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,5 +49,11 @@ public class IntervalSystemTest {
 			engine.update(deltaTime);
 			assertEquals(i / 2, intervalSystemSpy.numUpdates);
 		}
+	}
+
+	@Test
+	public void testGetInterval () {
+		IntervalSystemSpy intervalSystemSpy = new IntervalSystemSpy();
+		assertEquals(intervalSystemSpy.getInterval(), deltaTime * 2.0f, 0);
 	}
 }


### PR DESCRIPTION
This change makes it possible for subclasses to access the interval
directly.
Also fixes the [example on the wiki](https://github.com/libgdx/ashley/wiki/Built-in-Entity-Systems#intervalsystem), where the private field interval is used.