### PR TITLE
Allow temporary enable and disable of components on an Entity

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Entity.java
+++ b/ashley/src/com/badlogic/ashley/core/Entity.java
@@ -121,6 +121,54 @@ public class Entity {
 	}
 
 	/**
+	 * Disable the component on this {@link Entity} by class.  Does nothing if a component of the given class
+	 * is not already added to this {@link Entity}.  If such a component is already added, then it remains
+	 * added, but subsequent calls to {@link #hasComponent(ComponentType)} will return false.
+	 * <em>Note:</em> This method may be useful to temporarily exclude an {@link Entity} from an
+	 * {@link EntitySystem}, if the intention is to include the same component again later.
+	 * @param componentClass The {@link Class} of the component to be disabled.
+	 * @return The {@link Entity} for easy chaining
+	 */
+	public Entity disable(Class<? extends Component> componentClass) {
+		Component c = getComponent(componentClass);
+		if (c != null) {
+			componentBits.clear(ComponentType.getIndexFor(componentClass));
+		}
+		return this;
+	}
+
+	/**
+	 * Enable the component on this {@link Entity} by class.  Does nothing if a component of the given class
+	 * is not already added to this {@link Entity}.
+	 * @see #disable(Class<? extends Component>)
+	 * @param componentClass The {@link Class} of the component to be disabled.
+	 * @return The {@link Entity} for easy chaining
+	 */
+	public Entity enable(Class<? extends Component> componentClass) {
+		Component c = getComponent(componentClass);
+		if (c != null) {
+			componentBits.set(ComponentType.getIndexFor(componentClass));
+		}
+		return this;
+	}
+
+	/**
+	 * Enable or disable the component on this {@link Entity} by class.  Does nothing if a component of the
+	 * given class is not already added to this {@link Entity}.
+	 * @see #disable(Class<? extends Component>)
+	 * @see #enable(Class<? extends Component>)
+	 * @param componentClass The {@link Class} of the component to be disabled.
+	 * @return The {@link Entity} for easy chaining
+	 */
+	public Entity toggle(Class<? extends Component> componentClass) {
+		Component c = getComponent(componentClass);
+		if (c != null) {
+			componentBits.flip(ComponentType.getIndexFor(componentClass));
+		}
+		return this;
+	}
+
+	/**
 	 * Internal use.
 	 * @return The {@link Component} object for the specified class, null if the Entity does not have any components for that class.
 	 */

--- a/ashley/tests/com/badlogic/ashley/core/EntityTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EntityTests.java
@@ -198,4 +198,60 @@ public class EntityTests {
 		assertTrue(retA == compA);
 		assertTrue(retB == compB);
 	}
+
+	@Test
+	public void toggleComponentByClass () {
+		ComponentA compA = new ComponentA();
+		ComponentB compB = new ComponentB();
+
+		Entity entity = new Entity();
+		entity.add(compA).add(compB).toggle(compB.getClass());
+
+		assertTrue(entity.hasComponent(ComponentType.getFor(ComponentA.class)));
+		assertFalse(entity.hasComponent(ComponentType.getFor(ComponentB.class)));
+		assertNotNull(entity.getComponent(ComponentB.class));
+
+		entity.toggle(compB.getClass());
+
+		assertTrue(entity.hasComponent(ComponentType.getFor(ComponentB.class)));
+	}
+
+	@Test
+	public void toggleComponentByClassNotInEntity () {
+		ComponentA compA = new ComponentA();
+
+		Entity entity = new Entity();
+		entity.add(compA).toggle(ComponentB.class);
+
+		assertTrue(entity.hasComponent(ComponentType.getFor(ComponentA.class)));
+		assertFalse(entity.hasComponent(ComponentType.getFor(ComponentB.class)));
+		assertNull(entity.getComponent(ComponentB.class));
+	}
+
+	@Test
+	public void disableComponentByClass () {
+		ComponentA compA = new ComponentA();
+		ComponentB compB = new ComponentB();
+
+		Entity entity = new Entity();
+		entity.add(compA).add(compB).disable(compB.getClass());
+
+		assertTrue(entity.hasComponent(ComponentType.getFor(ComponentA.class)));
+		assertFalse(entity.hasComponent(ComponentType.getFor(ComponentB.class)));
+		assertNotNull(entity.getComponent(ComponentB.class));
+	}
+
+	@Test
+	public void enableComponentByClass () {
+		ComponentA compA = new ComponentA();
+		ComponentB compB = new ComponentB();
+
+		Entity entity = new Entity();
+		entity.add(compA).add(compB).disable(compB.getClass()).enable(compB.getClass());
+
+		assertTrue(entity.hasComponent(ComponentType.getFor(ComponentA.class)));
+		assertTrue(entity.hasComponent(ComponentType.getFor(ComponentB.class)));
+		assertNotNull(entity.getComponent(ComponentB.class));
+	}
+
 }


### PR DESCRIPTION
Here's a use-case I'd like to discuss.  

I have a simple game in which Entities have PositionComponents and VelocityComponents.  A MovementSystem handles these Entities in the obvious way.  When the entities are clicked upon, they should become stationary.  When the entities are clicked again, they should continue moving with their original velocity.

I figure that either I can:
1. Remove and re-add the Velocity component, storing it as state somewhere in the meantime.  Or, 
2. Add an empty marker Component like 'MovingComponent' that is added / removed from the Entity to include / exclude from the MovementSystem.

For 1, it's a shame to have to hold the state elsewhere, adding complexity to my code that Ashley has so nicely cleaned up.  For 2, it feels like a work-around.

I propose here a change that allows me to merely toggle the VelocityComponent on the Entity each time it is clicked upon, thereby excluding and including from the MovementSystem.

I'm new to Ashley, so there may a better way to do what I want.