### PR TITLE
Splits Engine implementation into multiple classes #178

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/ComponentOperationHandler.java
+++ b/ashley/src/com/badlogic/ashley/core/ComponentOperationHandler.java
@@ -1,0 +1,93 @@
+package com.badlogic.ashley.core;
+
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Pool;
+
+
+class ComponentOperationHandler {
+	private BooleanInformer delayed;
+	private ComponentOperationPool operationPool = new ComponentOperationPool();;
+ 	private Array<ComponentOperation> operations = new Array<ComponentOperation>();;
+
+ 	public ComponentOperationHandler(BooleanInformer delayed) {
+ 		this.delayed = delayed;
+ 	}
+ 	
+	public void add(Entity entity) {
+		if (delayed.value()) {
+			ComponentOperation operation = operationPool.obtain();
+			operation.makeAdd(entity);
+			operations.add(operation);
+		}
+		else {
+			entity.notifyComponentAdded();
+		}
+	}
+
+	public void remove(Entity entity) {
+		if (delayed.value()) {
+			ComponentOperation operation = operationPool.obtain();
+			operation.makeRemove(entity);
+			operations.add(operation);
+		}
+		else {
+			entity.notifyComponentRemoved();
+		}
+	}
+	
+	public void processOperations() {
+		for (int i = 0; i < operations.size; ++i) {
+			ComponentOperation operation = operations.get(i);
+
+			switch(operation.type) {
+				case Add:
+					operation.entity.notifyComponentAdded();
+					break;
+				case Remove:
+					operation.entity.notifyComponentRemoved();
+					break;
+				default: break;
+			}
+
+			operationPool.free(operation);
+		}
+
+		operations.clear();
+	}
+	
+	private static class ComponentOperation implements Pool.Poolable {
+		public enum Type {
+			Add,
+			Remove,
+		}
+
+		public Type type;
+		public Entity entity;
+
+		public void makeAdd(Entity entity) {
+			this.type = Type.Add;
+			this.entity = entity;
+		}
+
+		public void makeRemove(Entity entity) {
+			this.type = Type.Remove;
+			this.entity = entity;
+		}
+
+		@Override
+		public void reset() {
+			entity = null;
+		}
+	}
+	
+	private static class ComponentOperationPool extends Pool<ComponentOperation> {
+		@Override
+		protected ComponentOperation newObject() {
+			return new ComponentOperation();
+		}
+	}
+	
+	interface BooleanInformer {
+		public boolean value();
+	}
+}

--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -16,17 +16,11 @@
 
 package com.badlogic.ashley.core;
 
-import java.util.Comparator;
-
+import com.badlogic.ashley.core.ComponentOperationHandler.BooleanInformer;
+import com.badlogic.ashley.core.SystemManager.SystemListener;
 import com.badlogic.ashley.signals.Listener;
 import com.badlogic.ashley.signals.Signal;
 import com.badlogic.ashley.utils.ImmutableArray;
-import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.Bits;
-import com.badlogic.gdx.utils.ObjectMap;
-import com.badlogic.gdx.utils.ObjectSet;
-import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.SnapshotArray;
 
 /**
  * The heart of the Entity framework. It is responsible for keeping track of {@link Entity} and
@@ -45,56 +39,17 @@ import com.badlogic.gdx.utils.SnapshotArray;
  * @author Stefan Bachmann
  */
 public class Engine {
-	private static SystemComparator systemComparator = new SystemComparator();
 	private static Family empty = Family.all().get();
 	
-	private final Listener<Entity> componentAdded;
-	private final Listener<Entity> componentRemoved;
+	private final Listener<Entity> componentAdded = new ComponentListener();
+	private final Listener<Entity> componentRemoved = new ComponentListener();
 	
-	private Array<Entity> entities;
-	private ObjectSet<Entity> entitySet;
-	private ImmutableArray<Entity> immutableEntities;
-	private Array<EntityOperation> entityOperations;
-	private EntityOperationPool entityOperationPool;
-	private Array<EntitySystem> systems;
-	private ImmutableArray<EntitySystem> immutableSystems;
-	private ObjectMap<Class<?>, EntitySystem> systemsByClass;
-	private ObjectMap<Family, Array<Entity>> families;
-	private ObjectMap<Family, ImmutableArray<Entity>> immutableFamilies;
-	private SnapshotArray<EntityListenerData> entityListeners;
-	private ObjectMap<Family, Bits> entityListenerMasks;
+	private SystemManager systemManager = new SystemManager(new EngineSystemListener());
+	private EntityManager entityManager = new EntityManager(new EngineEntityListener());
+	private ComponentOperationHandler componentOperationHandler = new ComponentOperationHandler(new EngineDelayedInformer());
+	private FamilyManager familyManager = new FamilyManager(entityManager.getEntities());	
 	private boolean updating;
-	private boolean notifying;
-	private ComponentOperationPool componentOperationsPool;
- 	private Array<ComponentOperation> componentOperations;
- 	private ComponentOperationHandler componentOperationHandler;
- 	
- 	private BitsPool bitsPool = new BitsPool();
 
-	public Engine(){
-		entities = new Array<Entity>(false, 16);
-		entitySet = new ObjectSet<Entity>();
-		immutableEntities = new ImmutableArray<Entity>(entities);
-		entityOperations = new Array<EntityOperation>(false, 16);
-		entityOperationPool = new EntityOperationPool();
-		systems = new Array<EntitySystem>(false, 16);
-		immutableSystems = new ImmutableArray<EntitySystem>(systems);
-		systemsByClass = new ObjectMap<Class<?>, EntitySystem>();
-		families = new ObjectMap<Family, Array<Entity>>();
-		immutableFamilies = new ObjectMap<Family, ImmutableArray<Entity>>();
-		entityListeners = new SnapshotArray<EntityListenerData>(true, 16);
-		entityListenerMasks = new ObjectMap<Family, Bits>();
-
-		componentAdded = new ComponentListener(this);
-		componentRemoved = new ComponentListener(this);
-
-		updating = false;
-		notifying = false;
-
-		componentOperationsPool = new ComponentOperationPool();
-		componentOperations = new Array<ComponentOperation>();
-		componentOperationHandler = new ComponentOperationHandler(this);
-	}
 
 	/**
 	 * Adds an entity to this Engine.
@@ -102,61 +57,28 @@ public class Engine {
 	 * was already registered with an engine.
 	 */
 	public void addEntity(Entity entity){
-		if (entitySet.contains(entity)) {
-			throw new IllegalArgumentException("Entity is already registered with the Engine " + entity);
-		}
-		
-		if (updating || notifying) {
-			EntityOperation operation = entityOperationPool.obtain();
-			operation.entity = entity;
-			operation.type = EntityOperation.Type.Add;
-			entityOperations.add(operation);
-		}
-		else {
-			addEntityInternal(entity);
-		}
+		boolean delayed = updating || familyManager.notifying();
+		entityManager.addEntity(entity, delayed);
 	}
 
 	/**
 	 * Removes an entity from this Engine.
 	 */
 	public void removeEntity(Entity entity){
-		if (updating || notifying) {
-			if(entity.scheduledForRemoval) {
-				return;
-			}
-			entity.scheduledForRemoval = true;
-			EntityOperation operation = entityOperationPool.obtain();
-			operation.entity = entity;
-			operation.type = EntityOperation.Type.Remove;
-			entityOperations.add(operation);
-		}
-		else {
-			removeEntityInternal(entity);
-		}
+		boolean delayed = updating || familyManager.notifying();
+		entityManager.removeEntity(entity, delayed);
 	}
 
 	/**
 	 * Removes all entities registered with this Engine.
 	 */
 	public void removeAllEntities() {
-		if (updating || notifying) {
-			for(Entity entity: entities) {
-				entity.scheduledForRemoval = true;
-			}
-			EntityOperation operation = entityOperationPool.obtain();
-			operation.type = EntityOperation.Type.RemoveAll;
-			entityOperations.add(operation);
-		}
-		else {
-			while(entities.size > 0) {
-				removeEntity(entities.first());
-			}
-		}
+		boolean delayed = updating || familyManager.notifying();
+		entityManager.removeAllEntities(delayed);
 	}
 
 	public ImmutableArray<Entity> getEntities() {
-		return immutableEntities;
+		return entityManager.getEntities();
 	}
 
 	/**
@@ -165,28 +87,14 @@ public class Engine {
 	 * the new one will replace the old one.
 	 */
 	public void addSystem(EntitySystem system){
-		Class<? extends EntitySystem> systemType = system.getClass();		
-		EntitySystem oldSystem = getSystem(systemType);
-		
-		if (oldSystem != null) {
-			removeSystem(oldSystem);
-		}
-		
-		systems.add(system);
-		systemsByClass.put(systemType, system);
-		system.addedToEngineInternal(this);
-
-		systems.sort(systemComparator);
+		systemManager.addSystem(system);
 	}
 
 	/**
 	 * Removes the {@link EntitySystem} from this Engine.
 	 */
 	public void removeSystem(EntitySystem system){
-		if(systems.removeValue(system, true)) {
-			systemsByClass.remove(system.getClass());
-			system.removedFromEngineInternal(this);
-		}
+		systemManager.removeSystem(system);
 	}
 
 	/**
@@ -194,21 +102,21 @@ public class Engine {
 	 */
 	@SuppressWarnings("unchecked")
 	public <T extends EntitySystem> T getSystem(Class<T> systemType) {
-		return (T) systemsByClass.get(systemType);
+		return systemManager.getSystem(systemType);
 	}
 
 	/**
 	 * @return immutable array of all entity systems managed by the {@link Engine}.
 	 */
 	public ImmutableArray<EntitySystem> getSystems() {
-		return immutableSystems;
+		return systemManager.getSystems();
 	}
 
 	/**
 	 * Returns immutable collection of entities for the specified {@link Family}. Will return the same instance every time.
 	 */
 	public ImmutableArray<Entity> getEntitiesFor(Family family){
-		return registerFamily(family);
+		return familyManager.getEntitiesFor(family);
 	}
 
 	/**
@@ -244,58 +152,14 @@ public class Engine {
 	 * value means it will get executed first.
 	 */
 	public void addEntityListener (Family family, int priority, EntityListener listener) {
-		registerFamily(family);
-
-		int insertionIndex = 0;
-		while (insertionIndex < entityListeners.size) {
-			if (entityListeners.get(insertionIndex).priority <= priority) {
-				insertionIndex++;
-			} else {
-				break;
-			}
-		}
-
-		// Shift up bitmasks by one step
-		for (Bits mask : entityListenerMasks.values()) {
-			for (int k = mask.length(); k > insertionIndex; k--) {
-				if (mask.get(k - 1)) {
-					mask.set(k);
-				} else {
-					mask.clear(k);
-				}
-			}
-			mask.clear(insertionIndex);
-		}
-
-		entityListenerMasks.get(family).set(insertionIndex);
-
-		EntityListenerData entityListenerData = new EntityListenerData();
-		entityListenerData.listener = listener;
-		entityListenerData.priority = priority;
-		entityListeners.insert(insertionIndex, entityListenerData);
+		familyManager.addEntityListener(family, priority, listener);
 	}
 
 	/**
 	 * Removes an {@link EntityListener}
 	 */
 	public void removeEntityListener (EntityListener listener) {
-		for (int i = 0; i < entityListeners.size; i++) {
-			EntityListenerData entityListenerData = entityListeners.get(i);
-			if (entityListenerData.listener == listener) {
-				// Shift down bitmasks by one step
-				for (Bits mask : entityListenerMasks.values()) {
-					for (int k = i, n = mask.length(); k < n; k++) {
-						if (mask.get(k + 1)) {
-							mask.set(k);
-						} else {
-							mask.clear(k);
-						}
-					}
-				}
-
-				entityListeners.removeIndex(i--);
-			}
-		}
+		familyManager.removeEntityListener(listener);
 	}
 
 	/**
@@ -308,265 +172,68 @@ public class Engine {
 		}
 		
 		updating = true;
-		for(int i=0; i<systems.size; i++){
-			EntitySystem system = systems.get(i);
+		for (EntitySystem system : systemManager.getSystems()) {
 			if (system.checkProcessing()) {
 				system.update(deltaTime);
 			}
 
-			processComponentOperations();
-			processPendingEntityOperations();
+			componentOperationHandler.processOperations();
+			entityManager.processPendingOperations();
 		}
-
 		updating = false;
 	}
-
-	private void updateFamilyMembership (Entity entity, boolean removing) {
-		// Find families that the entity was added to/removed from, and fill
-		// the bitmasks with corresponding listener bits.
-		Bits addListenerBits = bitsPool.obtain();
-		Bits removeListenerBits = bitsPool.obtain();
-
-		for (Family family : entityListenerMasks.keys()) {
-			final int familyIndex = family.getIndex();
-			final Bits entityFamilyBits = entity.getFamilyBits();
-
-			boolean belongsToFamily = entityFamilyBits.get(familyIndex);
-			boolean matches = family.matches(entity) && !removing;
-
-			if (belongsToFamily != matches) {
-				final Bits listenersMask = entityListenerMasks.get(family);
-				final Array<Entity> familyEntities = families.get(family);
-				if (matches) {
-					addListenerBits.or(listenersMask);
-					familyEntities.add(entity);
-					entityFamilyBits.set(familyIndex);
-				} else {
-					removeListenerBits.or(listenersMask);
-					familyEntities.removeValue(entity, true);
-					entityFamilyBits.clear(familyIndex);
-				}
-			}
-		}
-
-		// Notify listeners; set bits match indices of listeners
-		notifying = true;
-		Object[] items = entityListeners.begin();
-
-		for (int i = removeListenerBits.nextSetBit(0); i >= 0; i = removeListenerBits.nextSetBit(i + 1)) {
-			((EntityListenerData)items[i]).listener.entityRemoved(entity);
-		}
-
-		for (int i = addListenerBits.nextSetBit(0); i >= 0; i = addListenerBits.nextSetBit(i + 1)) {
-			((EntityListenerData)items[i]).listener.entityAdded(entity);
-		}
-
-		addListenerBits.clear();
-		removeListenerBits.clear();
-		bitsPool.free(addListenerBits);
-		bitsPool.free(removeListenerBits);
-		entityListeners.end();
-		notifying = false;
-	}
-
-	protected void removeEntityInternal(Entity entity) {
-		entity.scheduledForRemoval = false;
-		entities.removeValue(entity, true);
-		entitySet.remove(entity);
+	
+	protected void addEntityInternal(Entity entity) {
+		entity.componentAdded.add(componentAdded);
+		entity.componentRemoved.add(componentRemoved);
+		entity.componentOperationHandler = componentOperationHandler;
 		
-		updateFamilyMembership(entity, true);
+		familyManager.updateFamilyMembership(entity, false);
+	}
+	
+	protected void removeEntityInternal(Entity entity) {
+		familyManager.updateFamilyMembership(entity, true);
 
 		entity.componentAdded.remove(componentAdded);
 		entity.componentRemoved.remove(componentRemoved);
 		entity.componentOperationHandler = null;
 	}
-
-	protected void addEntityInternal(Entity entity) {
-		entities.add(entity);
-		entitySet.add(entity);
-
-		entity.componentAdded.add(componentAdded);
-		entity.componentRemoved.add(componentRemoved);
-
-		updateFamilyMembership(entity, false);
-
-		entity.componentOperationHandler = componentOperationHandler;
-	}
-
-	private ImmutableArray<Entity> registerFamily(Family family) {
-		ImmutableArray<Entity> immutableEntitiesInFamily = immutableFamilies.get(family);
-
-		if (immutableEntitiesInFamily == null) {
-			Array<Entity> familyEntities = new Array<Entity>(false, 16);
-			immutableEntitiesInFamily = new ImmutableArray<Entity>(familyEntities);
-			families.put(family, familyEntities);
-			immutableFamilies.put(family, immutableEntitiesInFamily);
-			entityListenerMasks.put(family, new Bits());
-
-			for (Entity entity : this.entities){
-				updateFamilyMembership(entity, false);
-			}
-		}
-
-		return immutableEntitiesInFamily;
-	}
-
-	private void processPendingEntityOperations() {
-		while (entityOperations.size > 0) {
-			EntityOperation operation = entityOperations.removeIndex(entityOperations.size - 1);
-
-			switch(operation.type) {
-				case Add: addEntityInternal(operation.entity); break;
-				case Remove: removeEntityInternal(operation.entity); break;
-				case RemoveAll:
-					while(entities.size > 0) {
-						removeEntityInternal(entities.first());
-					}
-					break;
-				default:
-					throw new AssertionError("Unexpected EntityOperation type");
-			}
-
-			entityOperationPool.free(operation);
-		}
-
-		entityOperations.clear();
-	}
-
-	private void processComponentOperations() {
-		for (int i = 0; i < componentOperations.size; ++i) {
-			ComponentOperation operation = componentOperations.get(i);
-
-			switch(operation.type) {
-				case Add:
-					operation.entity.notifyComponentAdded();
-					break;
-				case Remove:
-					operation.entity.notifyComponentRemoved();
-					break;
-				default: break;
-			}
-
-			componentOperationsPool.free(operation);
-		}
-
-		componentOperations.clear();
-	}
-
-	private static class ComponentListener implements Listener<Entity> {
-		private Engine engine;
-
-		public ComponentListener(Engine engine) {
-			this.engine = engine;
-		}
-
+	
+	private class ComponentListener implements Listener<Entity> {
 		@Override
 		public void receive(Signal<Entity> signal, Entity object) {
-			engine.updateFamilyMembership(object, false);
-		}
-	}
-
-	static class ComponentOperationHandler {
-		private Engine engine;
-
-		public ComponentOperationHandler(Engine engine) {
-			this.engine = engine;
-		}
-
-		public void add(Entity entity) {
-			if (engine.updating) {
-				ComponentOperation operation = engine.componentOperationsPool.obtain();
-				operation.makeAdd(entity);
-				engine.componentOperations.add(operation);
-			}
-			else {
-				entity.notifyComponentAdded();
-			}
-		}
-
-		public void remove(Entity entity) {
-			if (engine.updating) {
-				ComponentOperation operation = engine.componentOperationsPool.obtain();
-				operation.makeRemove(entity);
-				engine.componentOperations.add(operation);
-			}
-			else {
-				entity.notifyComponentRemoved();
-			}
-		}
-	}
-
-	private static class ComponentOperation implements Pool.Poolable {
-		public enum Type {
-			Add,
-			Remove,
-		}
-
-		public Type type;
-		public Entity entity;
-
-		public void makeAdd(Entity entity) {
-			this.type = Type.Add;
-			this.entity = entity;
-		}
-
-		public void makeRemove(Entity entity) {
-			this.type = Type.Remove;
-			this.entity = entity;
-		}
-
-		@Override
-		public void reset() {
-			entity = null;
-		}
-	}
-
-	private static class ComponentOperationPool extends Pool<ComponentOperation> {
-		@Override
-		protected ComponentOperation newObject() {
-			return new ComponentOperation();
-		}
-	}
-
-	private static class EntityListenerData {
-		public EntityListener listener;
-		public int priority;
-	}
-
-	private static class SystemComparator implements Comparator<EntitySystem>{
-		@Override
-		public int compare(EntitySystem a, EntitySystem b) {
-			return a.priority > b.priority ? 1 : (a.priority == b.priority) ? 0 : -1;
-		}
-	}
-
-	private static class EntityOperation implements Pool.Poolable {
-		public enum Type {
-			Add,
-			Remove,
-			RemoveAll
-		}
-
-		public Type type;
-		public Entity entity;
-
-		@Override
-		public void reset() {
-			entity = null;
-		}
-	}
-
-	private static class EntityOperationPool extends Pool<EntityOperation> {
-		@Override
-		protected EntityOperation newObject() {
-			return new EntityOperation();
+			familyManager.updateFamilyMembership(object, false);
 		}
 	}
 	
-	private static class BitsPool extends Pool<Bits> {
+	private class EngineSystemListener implements SystemListener {
 		@Override
-		protected Bits newObject () {
-			return new Bits();
+		public void systemAdded (EntitySystem system) {
+			system.addedToEngineInternal(Engine.this);
+		}
+
+		@Override
+		public void systemRemoved (EntitySystem system) {
+			system.removedFromEngineInternal(Engine.this);
+		}
+	}
+	
+	private class EngineEntityListener implements EntityListener {
+		@Override
+		public void entityAdded (Entity entity) {
+			addEntityInternal(entity);
+		}
+
+		@Override
+		public void entityRemoved (Entity entity) {
+			removeEntityInternal(entity);
+		}
+	}
+	
+	private class EngineDelayedInformer implements BooleanInformer {
+		@Override
+		public boolean value () {
+			return updating;
 		}
 	}
 }

--- a/ashley/src/com/badlogic/ashley/core/Entity.java
+++ b/ashley/src/com/badlogic/ashley/core/Entity.java
@@ -16,7 +16,6 @@
 
 package com.badlogic.ashley.core;
 
-import com.badlogic.ashley.core.Engine.ComponentOperationHandler;
 import com.badlogic.ashley.signals.Signal;
 import com.badlogic.ashley.utils.Bag;
 import com.badlogic.ashley.utils.ImmutableArray;

--- a/ashley/src/com/badlogic/ashley/core/EntityManager.java
+++ b/ashley/src/com/badlogic/ashley/core/EntityManager.java
@@ -1,0 +1,144 @@
+package com.badlogic.ashley.core;
+
+
+import com.badlogic.ashley.utils.ImmutableArray;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectSet;
+import com.badlogic.gdx.utils.Pool;
+
+class EntityManager {
+	private EntityListener listener;
+	private Array<Entity> entities = new Array<Entity>(false, 16);
+	private ObjectSet<Entity> entitySet = new ObjectSet<Entity>();
+	private ImmutableArray<Entity> immutableEntities = new ImmutableArray<Entity>(entities);
+	private Array<EntityOperation> entityOperations = new Array<EntityOperation>(false, 16);
+	private EntityOperationPool entityOperationPool = new EntityOperationPool();
+	
+	public EntityManager(EntityListener listener) {
+		this.listener = listener;
+	}
+	
+	public void addEntity(Entity entity){
+		addEntity(entity, false);
+	}
+	
+	public void addEntity(Entity entity, boolean delayed){
+		if (entitySet.contains(entity)) {
+			throw new IllegalArgumentException("Entity is already registered " + entity);
+		}
+		
+		if (delayed) {
+			EntityOperation operation = entityOperationPool.obtain();
+			operation.entity = entity;
+			operation.type = EntityOperation.Type.Add;
+			entityOperations.add(operation);
+		}
+		else {
+			addEntityInternal(entity);
+		}
+	}
+	
+	public void removeEntity(Entity entity){
+		removeEntity(entity, false);
+	}
+	
+	public void removeEntity(Entity entity, boolean delayed){
+		if (delayed) {
+			if(entity.scheduledForRemoval) {
+				return;
+			}
+			entity.scheduledForRemoval = true;
+			EntityOperation operation = entityOperationPool.obtain();
+			operation.entity = entity;
+			operation.type = EntityOperation.Type.Remove;
+			entityOperations.add(operation);
+		}
+		else {
+			removeEntityInternal(entity);
+		}
+	}
+	
+	public void removeAllEntities() {
+		removeAllEntities(false);
+	}
+	
+	public void removeAllEntities(boolean delayed) {
+		if (delayed) {
+			for(Entity entity: entities) {
+				entity.scheduledForRemoval = true;
+			}
+			EntityOperation operation = entityOperationPool.obtain();
+			operation.type = EntityOperation.Type.RemoveAll;
+			entityOperations.add(operation);
+		}
+		else {
+			while(entities.size > 0) {
+				removeEntity(entities.first(), false);
+			}
+		}
+	}
+	
+	public ImmutableArray<Entity> getEntities() {
+		return immutableEntities;
+	}
+	
+	public void processPendingOperations() {
+		while (entityOperations.size > 0) {
+			EntityOperation operation = entityOperations.removeIndex(entityOperations.size - 1);
+
+			switch(operation.type) {
+				case Add: addEntityInternal(operation.entity); break;
+				case Remove: removeEntityInternal(operation.entity); break;
+				case RemoveAll:
+					while(entities.size > 0) {
+						removeEntityInternal(entities.first());
+					}
+					break;
+				default:
+					throw new AssertionError("Unexpected EntityOperation type");
+			}
+
+			entityOperationPool.free(operation);
+		}
+
+		entityOperations.clear();
+	}
+	
+	protected void removeEntityInternal(Entity entity) {
+		entity.scheduledForRemoval = false;
+		entities.removeValue(entity, true);
+		entitySet.remove(entity);
+		
+		listener.entityRemoved(entity);
+	}
+
+	protected void addEntityInternal(Entity entity) {
+		entities.add(entity);
+		entitySet.add(entity);
+
+		listener.entityAdded(entity);
+	}
+	
+	private static class EntityOperation implements Pool.Poolable {
+		public enum Type {
+			Add,
+			Remove,
+			RemoveAll
+		}
+
+		public Type type;
+		public Entity entity;
+
+		@Override
+		public void reset() {
+			entity = null;
+		}
+	}
+
+	private static class EntityOperationPool extends Pool<EntityOperation> {
+		@Override
+		protected EntityOperation newObject() {
+			return new EntityOperation();
+		}
+	}
+}

--- a/ashley/src/com/badlogic/ashley/core/FamilyManager.java
+++ b/ashley/src/com/badlogic/ashley/core/FamilyManager.java
@@ -1,0 +1,160 @@
+package com.badlogic.ashley.core;
+
+import com.badlogic.ashley.utils.ImmutableArray;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Bits;
+import com.badlogic.gdx.utils.ObjectMap;
+import com.badlogic.gdx.utils.Pool;
+import com.badlogic.gdx.utils.SnapshotArray;
+
+class FamilyManager {
+	ImmutableArray<Entity> entities;
+	private ObjectMap<Family, Array<Entity>> families = new ObjectMap<Family, Array<Entity>>();
+	private ObjectMap<Family, ImmutableArray<Entity>> immutableFamilies = new ObjectMap<Family, ImmutableArray<Entity>>();
+	private SnapshotArray<EntityListenerData> entityListeners = new SnapshotArray<EntityListenerData>(true, 16);
+	private ObjectMap<Family, Bits> entityListenerMasks = new ObjectMap<Family, Bits>();
+	private BitsPool bitsPool = new BitsPool();
+	private boolean notifying = false;
+	
+	public FamilyManager(ImmutableArray<Entity> entities) {
+		this.entities = entities;
+	}
+	
+	public ImmutableArray<Entity> getEntitiesFor(Family family) {
+		return registerFamily(family);
+	}
+	
+	public boolean notifying() {
+		return notifying;
+	}
+	
+	public void addEntityListener (Family family, int priority, EntityListener listener) {
+		registerFamily(family);
+
+		int insertionIndex = 0;
+		while (insertionIndex < entityListeners.size) {
+			if (entityListeners.get(insertionIndex).priority <= priority) {
+				insertionIndex++;
+			} else {
+				break;
+			}
+		}
+
+		// Shift up bitmasks by one step
+		for (Bits mask : entityListenerMasks.values()) {
+			for (int k = mask.length(); k > insertionIndex; k--) {
+				if (mask.get(k - 1)) {
+					mask.set(k);
+				} else {
+					mask.clear(k);
+				}
+			}
+			mask.clear(insertionIndex);
+		}
+
+		entityListenerMasks.get(family).set(insertionIndex);
+
+		EntityListenerData entityListenerData = new EntityListenerData();
+		entityListenerData.listener = listener;
+		entityListenerData.priority = priority;
+		entityListeners.insert(insertionIndex, entityListenerData);
+	}
+	
+	public void removeEntityListener (EntityListener listener) {
+		for (int i = 0; i < entityListeners.size; i++) {
+			EntityListenerData entityListenerData = entityListeners.get(i);
+			if (entityListenerData.listener == listener) {
+				// Shift down bitmasks by one step
+				for (Bits mask : entityListenerMasks.values()) {
+					for (int k = i, n = mask.length(); k < n; k++) {
+						if (mask.get(k + 1)) {
+							mask.set(k);
+						} else {
+							mask.clear(k);
+						}
+					}
+				}
+
+				entityListeners.removeIndex(i--);
+			}
+		}
+	}
+	
+	public void updateFamilyMembership (Entity entity, boolean removing) {
+		// Find families that the entity was added to/removed from, and fill
+		// the bitmasks with corresponding listener bits.
+		Bits addListenerBits = bitsPool.obtain();
+		Bits removeListenerBits = bitsPool.obtain();
+
+		for (Family family : entityListenerMasks.keys()) {
+			final int familyIndex = family.getIndex();
+			final Bits entityFamilyBits = entity.getFamilyBits();
+
+			boolean belongsToFamily = entityFamilyBits.get(familyIndex);
+			boolean matches = family.matches(entity) && !removing;
+
+			if (belongsToFamily != matches) {
+				final Bits listenersMask = entityListenerMasks.get(family);
+				final Array<Entity> familyEntities = families.get(family);
+				if (matches) {
+					addListenerBits.or(listenersMask);
+					familyEntities.add(entity);
+					entityFamilyBits.set(familyIndex);
+				} else {
+					removeListenerBits.or(listenersMask);
+					familyEntities.removeValue(entity, true);
+					entityFamilyBits.clear(familyIndex);
+				}
+			}
+		}
+
+		// Notify listeners; set bits match indices of listeners
+		notifying = true;
+		Object[] items = entityListeners.begin();
+
+		for (int i = removeListenerBits.nextSetBit(0); i >= 0; i = removeListenerBits.nextSetBit(i + 1)) {
+			((EntityListenerData)items[i]).listener.entityRemoved(entity);
+		}
+
+		for (int i = addListenerBits.nextSetBit(0); i >= 0; i = addListenerBits.nextSetBit(i + 1)) {
+			((EntityListenerData)items[i]).listener.entityAdded(entity);
+		}
+
+		addListenerBits.clear();
+		removeListenerBits.clear();
+		bitsPool.free(addListenerBits);
+		bitsPool.free(removeListenerBits);
+		entityListeners.end();
+		notifying = false;
+	}
+	
+	private ImmutableArray<Entity> registerFamily(Family family) {
+		ImmutableArray<Entity> entitiesInFamily = immutableFamilies.get(family);
+
+		if (entitiesInFamily == null) {
+			Array<Entity> familyEntities = new Array<Entity>(false, 16);
+			entitiesInFamily = new ImmutableArray<Entity>(familyEntities);
+			families.put(family, familyEntities);
+			immutableFamilies.put(family, entitiesInFamily);
+			entityListenerMasks.put(family, new Bits());
+
+			for (Entity entity : entities){
+				updateFamilyMembership(entity, false);
+			}
+		}
+
+		return entitiesInFamily;
+	}
+	
+	private static class EntityListenerData {
+		public EntityListener listener;
+		public int priority;
+	}
+	
+	private static class BitsPool extends Pool<Bits> {
+		@Override
+		protected Bits newObject () {
+			return new Bits();
+		}
+	}
+}

--- a/ashley/src/com/badlogic/ashley/core/SystemManager.java
+++ b/ashley/src/com/badlogic/ashley/core/SystemManager.java
@@ -1,0 +1,63 @@
+package com.badlogic.ashley.core;
+
+import java.util.Comparator;
+
+import com.badlogic.ashley.signals.Listener;
+import com.badlogic.ashley.signals.Signal;
+import com.badlogic.ashley.utils.ImmutableArray;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
+
+class SystemManager {
+	private SystemComparator systemComparator = new SystemComparator();
+	private Array<EntitySystem> systems = new Array<EntitySystem>(false, 16);
+	private ImmutableArray<EntitySystem> immutableSystems = new ImmutableArray<EntitySystem>(systems);
+	private ObjectMap<Class<?>, EntitySystem> systemsByClass = new ObjectMap<Class<?>, EntitySystem>();
+	private SystemListener listener;
+	
+	public SystemManager(SystemListener listener) {
+		this.listener = listener;
+	}
+	
+	public void addSystem(EntitySystem system){
+		Class<? extends EntitySystem> systemType = system.getClass();		
+		EntitySystem oldSytem = getSystem(systemType);
+		
+		if (oldSytem != null) {
+			removeSystem(oldSytem);
+		}
+		
+		systems.add(system);
+		systemsByClass.put(systemType, system);		
+		systems.sort(systemComparator);
+		listener.systemAdded(system);
+	}
+	
+	public void removeSystem(EntitySystem system){
+		if(systems.removeValue(system, true)) {
+			systemsByClass.remove(system.getClass());
+			listener.systemRemoved(system);
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	public <T extends EntitySystem> T getSystem(Class<T> systemType) {
+		return (T) systemsByClass.get(systemType);
+	}
+	
+	public ImmutableArray<EntitySystem> getSystems() {
+		return immutableSystems;
+	}
+	
+	private static class SystemComparator implements Comparator<EntitySystem>{
+		@Override
+		public int compare(EntitySystem a, EntitySystem b) {
+			return a.priority > b.priority ? 1 : (a.priority == b.priority) ? 0 : -1;
+		}
+	}
+	
+	interface SystemListener {
+		void systemAdded(EntitySystem system);
+		void systemRemoved(EntitySystem system);
+	}
+}

--- a/ashley/tests/com/badlogic/ashley/core/ComponentOperationHandlerTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/ComponentOperationHandlerTests.java
@@ -1,0 +1,98 @@
+package com.badlogic.ashley.core;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.badlogic.ashley.core.ComponentOperationHandler.BooleanInformer;
+import com.badlogic.ashley.signals.Listener;
+import com.badlogic.ashley.signals.Signal;
+
+public class ComponentOperationHandlerTests {
+
+	private static class BooleanInformerMock implements BooleanInformer {
+		public boolean delayed = false;
+		
+		@Override
+		public boolean value () {
+			return delayed;
+		}
+	}
+	
+	private static class ComponentSpy implements Listener<Entity> {
+		public boolean called;
+		
+		@Override
+		public void receive(Signal<Entity> signal, Entity object) {
+			called = true;
+		}
+	}
+	
+	@Test
+	public void add() {
+		ComponentSpy spy = new ComponentSpy();
+		BooleanInformerMock informer = new BooleanInformerMock();
+		ComponentOperationHandler handler = new ComponentOperationHandler(informer);
+		
+		Entity entity = new Entity();
+		entity.componentOperationHandler = handler;
+		entity.componentAdded.add(spy);
+		
+		handler.add(entity);
+		
+		assertTrue(spy.called);
+	}
+
+	@Test
+	public void addDelayed() {
+		ComponentSpy spy = new ComponentSpy();
+		BooleanInformerMock informer = new BooleanInformerMock();
+		ComponentOperationHandler handler = new ComponentOperationHandler(informer);
+		
+		informer.delayed = true;
+		
+		Entity entity = new Entity();
+		entity.componentOperationHandler = handler;
+		entity.componentAdded.add(spy);
+		
+		handler.add(entity);
+		
+		assertFalse(spy.called);
+		handler.processOperations();
+		assertTrue(spy.called);
+	}
+	
+	@Test
+	public void remove() {
+		ComponentSpy spy = new ComponentSpy();
+		BooleanInformerMock informer = new BooleanInformerMock();
+		ComponentOperationHandler handler = new ComponentOperationHandler(informer);
+		
+		Entity entity = new Entity();
+		entity.componentOperationHandler = handler;
+		entity.componentRemoved.add(spy);
+		
+		handler.remove(entity);
+		
+		assertTrue(spy.called);
+	}
+	
+	@Test
+	public void removeDelayed() {
+		ComponentSpy spy = new ComponentSpy();
+		BooleanInformerMock informer = new BooleanInformerMock();
+		ComponentOperationHandler handler = new ComponentOperationHandler(informer);
+		
+		informer.delayed = true;
+		
+		Entity entity = new Entity();
+		entity.componentOperationHandler = handler;
+		entity.componentRemoved.add(spy);
+		
+		handler.remove(entity);
+		
+		assertFalse(spy.called);
+		handler.processOperations();
+		assertTrue(spy.called);
+	}
+}

--- a/ashley/tests/com/badlogic/ashley/core/EngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EngineTests.java
@@ -584,7 +584,7 @@ public class EngineTests {
 		}
 	}
 	
-	public class ComponentAddedListener implements EntityListener {
+	public static class ComponentAddedListener implements EntityListener {
 		int addedCalls;
 		int numEntities;
 		
@@ -612,7 +612,7 @@ public class EngineTests {
 		}
 	}
 	
-	public class ComponentRemovedListener implements EntityListener {
+	public static class ComponentRemovedListener implements EntityListener {
 		int removedCalls;
 		int numEntities;
 		

--- a/ashley/tests/com/badlogic/ashley/core/EntityManagerTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EntityManagerTests.java
@@ -82,4 +82,30 @@ public class EntityManagerTests {
 	    manager.addEntity(entity);
 	    manager.addEntity(entity);
 	}
+	
+	@Test
+	public void delayedOperationsOrder() {
+		EntityListenerMock listener = new EntityListenerMock();
+		EntityManager manager = new EntityManager(listener);
+		
+		Entity entityA = new Entity();
+		Entity entityB = new Entity();
+		
+		boolean delayed = true;
+		manager.addEntity(entityA);
+		manager.addEntity(entityB);
+		
+		assertEquals(2, manager.getEntities().size());
+		
+		Entity entityC = new Entity();
+		Entity entityD = new Entity();
+		manager.removeAllEntities(delayed);
+		manager.addEntity(entityC, delayed);
+		manager.addEntity(entityD, delayed);
+		manager.processPendingOperations();
+		
+		assertEquals(2, manager.getEntities().size());
+		assertNotEquals(-1, manager.getEntities().indexOf(entityC, true));
+		assertNotEquals(-1, manager.getEntities().indexOf(entityD, true));
+	}
 }

--- a/ashley/tests/com/badlogic/ashley/core/EntityManagerTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EntityManagerTests.java
@@ -1,0 +1,85 @@
+package com.badlogic.ashley.core;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.badlogic.ashley.utils.ImmutableArray;
+import com.badlogic.gdx.utils.Array;
+
+public class EntityManagerTests {
+
+	private static class EntityListenerMock implements EntityListener {
+
+		public int addedCount = 0;
+		public int removedCount = 0;
+
+		@Override
+		public void entityAdded (Entity entity) {
+			++addedCount;
+			assertNotNull(entity);
+		}
+
+		@Override
+		public void entityRemoved (Entity entity) {
+			++removedCount;
+			assertNotNull(entity);
+		}
+	}
+	
+	@Test
+	public void addAndRemoveEntity () {
+		EntityListenerMock listener = new EntityListenerMock();
+		EntityManager manager = new EntityManager(listener);
+
+		Entity entity1 = new Entity();
+		manager.addEntity(entity1);
+
+		assertEquals(1, listener.addedCount);
+		Entity entity2 = new Entity();
+		manager.addEntity(entity2);
+
+		assertEquals(2, listener.addedCount);
+
+		manager.removeAllEntities();
+
+		assertEquals(2, listener.removedCount);
+	}
+	
+	@Test
+	public void getEntities () {
+		int numEntities = 10;
+		
+		EntityListenerMock listener = new EntityListenerMock();
+		EntityManager manager = new EntityManager(listener);
+		
+		Array<Entity> entities = new Array<Entity>();
+		
+		for (int i = 0; i < numEntities; ++i) {
+			Entity entity = new Entity();
+			entities.add(entity);
+			manager.addEntity(entity);
+		}
+		
+		ImmutableArray<Entity> engineEntities = manager.getEntities();
+		
+		assertEquals(entities.size, engineEntities.size());
+		
+		for (int i = 0; i < numEntities; ++i) {
+			assertEquals(entities.get(i), engineEntities.get(i));
+		}
+		
+		manager.removeAllEntities();
+		
+		assertEquals(0, engineEntities.size());
+	}
+	
+	@Test(expected=IllegalArgumentException.class)
+	public void addEntityTwice () {
+		 EntityListenerMock listener = new EntityListenerMock();
+		 EntityManager manager = new EntityManager(listener);
+	    Entity entity = new Entity();
+	    manager.addEntity(entity);
+	    manager.addEntity(entity);
+	}
+}

--- a/ashley/tests/com/badlogic/ashley/core/FamilyManagerTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/FamilyManagerTests.java
@@ -1,0 +1,229 @@
+package com.badlogic.ashley.core;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.badlogic.ashley.utils.ImmutableArray;
+import com.badlogic.gdx.utils.Array;
+
+
+public class FamilyManagerTests {
+
+	private static class ComponentA implements Component {}
+	private static class ComponentB implements Component {}
+	private static class ComponentC implements Component {}
+	
+	
+	@Test
+	public void entitiesForFamily () {
+		Array<Entity> entities = new Array<Entity>();
+		ImmutableArray<Entity> immutableEntities = new ImmutableArray<Entity>(entities);
+		FamilyManager manager = new FamilyManager(immutableEntities);
+		
+		Family family = Family.all(ComponentA.class, ComponentB.class).get();
+		ImmutableArray<Entity> familyEntities = manager.getEntitiesFor(family);
+
+		assertEquals(0, familyEntities.size());
+
+		Entity entity1 = new Entity();
+		Entity entity2 = new Entity();
+		Entity entity3 = new Entity();
+		Entity entity4 = new Entity();
+
+		entity1.add(new ComponentA());
+		entity1.add(new ComponentB());
+
+		entity2.add(new ComponentA());
+		entity2.add(new ComponentC());
+
+		entity3.add(new ComponentA());
+		entity3.add(new ComponentB());
+		entity3.add(new ComponentC());
+
+		entity4.add(new ComponentA());
+		entity4.add(new ComponentB());
+		entity4.add(new ComponentC());
+
+		entities.add(entity1);
+		entities.add(entity2);
+		entities.add(entity3);
+		entities.add(entity4);
+
+		manager.updateFamilyMembership(entity1, false);
+		manager.updateFamilyMembership(entity2, false);
+		manager.updateFamilyMembership(entity3, false);
+		manager.updateFamilyMembership(entity4, false);
+		
+		assertEquals(3, familyEntities.size());
+		assertTrue(familyEntities.contains(entity1, true));
+		assertTrue(familyEntities.contains(entity3, true));
+		assertTrue(familyEntities.contains(entity4, true));
+		assertFalse(familyEntities.contains(entity2, true));
+	}
+
+	@Test
+	public void entityForFamilyWithRemoval () {
+		Array<Entity> entities = new Array<Entity>();
+		ImmutableArray<Entity> immutableEntities = new ImmutableArray<Entity>(entities);
+		FamilyManager manager = new FamilyManager(immutableEntities);
+
+		Entity entity = new Entity();
+		entity.add(new ComponentA());
+
+		entities.add(entity);
+		
+		manager.updateFamilyMembership(entity, false);
+		
+		ImmutableArray<Entity> familyEntities = manager.getEntitiesFor(Family.all(ComponentA.class).get());
+		
+		assertEquals(1, familyEntities.size());
+		assertTrue(familyEntities.contains(entity, true));
+		
+		entities.removeValue(entity, true);
+		
+		manager.updateFamilyMembership(entity, true);
+
+		assertEquals(0, familyEntities.size());
+		assertFalse(familyEntities.contains(entity, true));
+	}
+
+	@Test
+	public void entitiesForFamilyAfter () {
+		Array<Entity> entities = new Array<Entity>();
+		ImmutableArray<Entity> immutableEntities = new ImmutableArray<Entity>(entities);
+		FamilyManager manager = new FamilyManager(immutableEntities);
+
+		Family family = Family.all(ComponentA.class, ComponentB.class).get();
+		ImmutableArray<Entity> familyEntities = manager.getEntitiesFor(family);
+
+		assertEquals(0, familyEntities.size());
+
+		Entity entity1 = new Entity();
+		Entity entity2 = new Entity();
+		Entity entity3 = new Entity();
+		Entity entity4 = new Entity();
+
+		entities.add(entity1);
+		entities.add(entity2);
+		entities.add(entity3);
+		entities.add(entity4);
+
+		entity1.add(new ComponentA());
+		entity1.add(new ComponentB());
+
+		entity2.add(new ComponentA());
+		entity2.add(new ComponentC());
+
+		entity3.add(new ComponentA());
+		entity3.add(new ComponentB());
+		entity3.add(new ComponentC());
+
+		entity4.add(new ComponentA());
+		entity4.add(new ComponentB());
+		entity4.add(new ComponentC());
+		
+		manager.updateFamilyMembership(entity1, false);
+		manager.updateFamilyMembership(entity2, false);
+		manager.updateFamilyMembership(entity3, false);
+		manager.updateFamilyMembership(entity4, false);
+
+		assertEquals(3, familyEntities.size());
+		assertTrue(familyEntities.contains(entity1, true));
+		assertTrue(familyEntities.contains(entity3, true));
+		assertTrue(familyEntities.contains(entity4, true));
+		assertFalse(familyEntities.contains(entity2, true));
+	}
+
+	@Test
+	public void entitiesForFamilyWithRemoval () {
+		Array<Entity> entities = new Array<Entity>();
+		ImmutableArray<Entity> immutableEntities = new ImmutableArray<Entity>(entities);
+		FamilyManager manager = new FamilyManager(immutableEntities);
+
+		Family family = Family.all(ComponentA.class, ComponentB.class).get();
+		ImmutableArray<Entity> familyEntities = manager.getEntitiesFor(family);
+
+		Entity entity1 = new Entity();
+		Entity entity2 = new Entity();
+		Entity entity3 = new Entity();
+		Entity entity4 = new Entity();
+
+		entities.add(entity1);
+		entities.add(entity2);
+		entities.add(entity3);
+		entities.add(entity4);
+
+		entity1.add(new ComponentA());
+		entity1.add(new ComponentB());
+
+		entity2.add(new ComponentA());
+		entity2.add(new ComponentC());
+
+		entity3.add(new ComponentA());
+		entity3.add(new ComponentB());
+		entity3.add(new ComponentC());
+
+		entity4.add(new ComponentA());
+		entity4.add(new ComponentB());
+		entity4.add(new ComponentC());
+		
+		manager.updateFamilyMembership(entity1, false);
+		manager.updateFamilyMembership(entity2, false);
+		manager.updateFamilyMembership(entity3, false);
+		manager.updateFamilyMembership(entity4, false);
+
+		assertEquals(3, familyEntities.size());
+		assertTrue(familyEntities.contains(entity1, true));
+		assertTrue(familyEntities.contains(entity3, true));
+		assertTrue(familyEntities.contains(entity4, true));
+		assertFalse(familyEntities.contains(entity2, true));
+	
+		entity1.remove(ComponentA.class);
+		entities.removeValue(entity3, true);
+
+		manager.updateFamilyMembership(entity1, false);
+		manager.updateFamilyMembership(entity3, true);
+		
+		assertEquals(1, familyEntities.size());
+		assertTrue(familyEntities.contains(entity4, true));
+		assertFalse(familyEntities.contains(entity1, true));
+		assertFalse(familyEntities.contains(entity3, true));
+		assertFalse(familyEntities.contains(entity2, true));
+	}
+
+	@Test
+	public void entitiesForFamilyWithRemovalAndFiltering () {
+		Array<Entity> entities = new Array<Entity>();
+		ImmutableArray<Entity> immutableEntities = new ImmutableArray<Entity>(entities);
+		FamilyManager manager = new FamilyManager(immutableEntities);
+
+		ImmutableArray<Entity> entitiesWithComponentAOnly = manager.getEntitiesFor(Family.all(ComponentA.class)
+			.exclude(ComponentB.class).get());
+
+		ImmutableArray<Entity> entitiesWithComponentB = manager.getEntitiesFor(Family.all(ComponentB.class).get());
+
+		Entity entity1 = new Entity();
+		Entity entity2 = new Entity();
+
+		entities.add(entity1);
+		entities.add(entity2);
+
+		entity1.add(new ComponentA());
+
+		entity2.add(new ComponentA());
+		entity2.add(new ComponentB());
+		
+		manager.updateFamilyMembership(entity1, false);
+		manager.updateFamilyMembership(entity2, false);
+
+		assertEquals(1, entitiesWithComponentAOnly.size());
+		assertEquals(1, entitiesWithComponentB.size());
+
+		entity2.remove(ComponentB.class);
+		
+		manager.updateFamilyMembership(entity2, false);
+
+		assertEquals(2, entitiesWithComponentAOnly.size());
+		assertEquals(0, entitiesWithComponentB.size());
+	}
+}

--- a/ashley/tests/com/badlogic/ashley/core/SystemManagerTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/SystemManagerTests.java
@@ -1,0 +1,179 @@
+package com.badlogic.ashley.core;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.badlogic.ashley.core.SystemManager.SystemListener;
+import com.badlogic.ashley.utils.ImmutableArray;
+import com.badlogic.gdx.utils.Array;
+
+public class SystemManagerTests {
+
+	private static class SystemListenerSpy implements SystemListener {
+		public int addedCount = 0;
+		public int removedCount = 0;
+		
+		@Override
+		public void systemAdded (EntitySystem system) {
+			system.addedToEngine(null);
+			++addedCount;
+		}
+
+		@Override
+		public void systemRemoved (EntitySystem system) {
+			system.removedFromEngine(null);
+			removedCount++;
+		}
+	}
+	
+	private static class EntitySystemMock extends EntitySystem {
+		public int addedCalls = 0;
+		public int removedCalls = 0;
+
+		private Array<Integer> updates;
+
+		public EntitySystemMock () {
+			super();
+		}
+
+		public EntitySystemMock (Array<Integer> updates) {
+			super();
+
+			this.updates = updates;
+		}
+
+		@Override
+		public void update (float deltaTime) {
+			if (updates != null) {
+				updates.add(priority);
+			}
+		}
+
+		@Override
+		public void addedToEngine (Engine engine) {
+			++addedCalls;
+		}
+
+		@Override
+		public void removedFromEngine (Engine engine) {
+			++removedCalls;
+		}
+	}
+
+	private static class EntitySystemMockA extends EntitySystemMock {
+
+		public EntitySystemMockA () {
+			super();
+		}
+
+		public EntitySystemMockA (Array<Integer> updates) {
+			super(updates);
+		}
+	}
+
+	private static class EntitySystemMockB extends EntitySystemMock {
+
+		public EntitySystemMockB () {
+			super();
+		}
+
+		public EntitySystemMockB (Array<Integer> updates) {
+			super(updates);
+		}
+	}
+	
+	@Test
+	public void addAndRemoveSystem () {
+		EntitySystemMockA systemA = new EntitySystemMockA();
+		EntitySystemMockB systemB = new EntitySystemMockB();
+		
+		SystemListenerSpy systemSpy = new SystemListenerSpy();
+		SystemManager manager = new SystemManager(systemSpy);
+
+		assertNull(manager.getSystem(EntitySystemMockA.class));
+		assertNull(manager.getSystem(EntitySystemMockB.class));
+
+		manager.addSystem(systemA);
+		manager.addSystem(systemB);
+
+		assertNotNull(manager.getSystem(EntitySystemMockA.class));
+		assertNotNull(manager.getSystem(EntitySystemMockB.class));
+		assertEquals(1, systemA.addedCalls);
+		assertEquals(1, systemB.addedCalls);
+
+		manager.removeSystem(systemA);
+		manager.removeSystem(systemB);
+
+		assertNull(manager.getSystem(EntitySystemMockA.class));
+		assertNull(manager.getSystem(EntitySystemMockB.class));
+		assertEquals(1, systemA.removedCalls);
+		assertEquals(1, systemB.removedCalls);
+	}
+
+	@Test
+	public void getSystems () {
+		SystemListenerSpy systemSpy = new SystemListenerSpy();
+		SystemManager manager = new SystemManager(systemSpy);
+		EntitySystemMockA systemA = new EntitySystemMockA();
+		EntitySystemMockB systemB = new EntitySystemMockB();
+
+		assertEquals(0, manager.getSystems().size());
+
+		manager.addSystem(systemA);
+		manager.addSystem(systemB);
+
+		assertEquals(2, manager.getSystems().size());
+		assertEquals(2, systemSpy.addedCount);
+		
+		manager.removeSystem(systemA);
+		manager.removeSystem(systemB);
+		
+		assertEquals(0, manager.getSystems().size());
+		assertEquals(2, systemSpy.addedCount);
+		assertEquals(2, systemSpy.removedCount);
+	}
+	
+	@Test
+	public void addTwoSystemsOfSameClass () {
+		SystemListenerSpy systemSpy = new SystemListenerSpy();
+		SystemManager manager = new SystemManager(systemSpy);
+		EntitySystemMockA system1 = new EntitySystemMockA();
+		EntitySystemMockA system2 = new EntitySystemMockA();
+
+		assertEquals(0, manager.getSystems().size());
+
+		manager.addSystem(system1);
+		
+		assertEquals(1, manager.getSystems().size());
+		assertEquals(system1, manager.getSystem(EntitySystemMockA.class));
+		assertEquals(1, systemSpy.addedCount);
+		
+		manager.addSystem(system2);
+
+		assertEquals(1, manager.getSystems().size());
+		assertEquals(system2, manager.getSystem(EntitySystemMockA.class));
+		assertEquals(2, systemSpy.addedCount);
+		assertEquals(1, systemSpy.removedCount);
+	}
+
+	@Test
+	public void systemUpdateOrder () {
+		Array<Integer> updates = new Array<Integer>();
+
+		SystemListenerSpy systemSpy = new SystemListenerSpy();
+		SystemManager manager = new SystemManager(systemSpy);
+		EntitySystemMock system1 = new EntitySystemMockA(updates);
+		EntitySystemMock system2 = new EntitySystemMockB(updates);
+
+		system1.priority = 2;
+		system2.priority = 1;
+
+		manager.addSystem(system1);
+		manager.addSystem(system2);
+
+		ImmutableArray<EntitySystem> systems = manager.getSystems();
+		assertEquals(system2, systems.get(0));
+		assertEquals(system1, systems.get(1));
+	}
+}


### PR DESCRIPTION
Engine is no longer a God-like class. The interface remains the same but it now delegates its logic onto:
* `EntityManager`
* `SystemManager`
* `FamilyManager`
* `ComponentOperationHandler`

The internal classes are package-protected because there's absolutely 0 need to expose them to the user. I could have made them internal private classes of the Engine, but it would have defeated the purpose.

I've added unit tests for each one of them and maintained `EngineTests` as integration tests.