### PR TITLE
Process delayed removal and addition of entities without exception

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/EntityManager.java
+++ b/ashley/src/com/badlogic/ashley/core/EntityManager.java
@@ -23,10 +23,6 @@ class EntityManager {
 	}
 	
 	public void addEntity(Entity entity, boolean delayed){
-		if (entitySet.contains(entity)) {
-			throw new IllegalArgumentException("Entity is already registered " + entity);
-		}
-		
 		if (delayed) {
 			EntityOperation operation = entityOperationPool.obtain();
 			operation.entity = entity;
@@ -113,6 +109,10 @@ class EntityManager {
 	}
 
 	protected void addEntityInternal(Entity entity) {
+		if (entitySet.contains(entity)) {
+			throw new IllegalArgumentException("Entity is already registered " + entity);
+		}
+
 		entities.add(entity);
 		entitySet.add(entity);
 

--- a/ashley/tests/com/badlogic/ashley/core/EntityManagerTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EntityManagerTests.java
@@ -75,14 +75,34 @@ public class EntityManagerTests {
 	}
 	
 	@Test(expected=IllegalArgumentException.class)
-	public void addEntityTwice () {
+	public void addEntityTwice1 () {
 		 EntityListenerMock listener = new EntityListenerMock();
 		 EntityManager manager = new EntityManager(listener);
 	    Entity entity = new Entity();
 	    manager.addEntity(entity);
 	    manager.addEntity(entity);
 	}
-	
+
+	@Test(expected=IllegalArgumentException.class)
+	public void addEntityTwice2() {
+		EntityListenerMock listener = new EntityListenerMock();
+		EntityManager manager = new EntityManager(listener);
+		Entity entity = new Entity();
+		manager.addEntity(entity, false);
+		manager.addEntity(entity, false);
+	}
+
+	@Test(expected=IllegalArgumentException.class)
+	public void addEntityTwiceDelayed() {
+		EntityListenerMock listener = new EntityListenerMock();
+		EntityManager manager = new EntityManager(listener);
+
+		Entity entity = new Entity();
+		manager.addEntity(entity, true);
+		manager.addEntity(entity, true);
+		manager.processPendingOperations();
+	}
+
 	@Test
 	public void delayedOperationsOrder() {
 		EntityListenerMock listener = new EntityListenerMock();
@@ -107,5 +127,43 @@ public class EntityManagerTests {
 		assertEquals(2, manager.getEntities().size());
 		assertNotEquals(-1, manager.getEntities().indexOf(entityC, true));
 		assertNotEquals(-1, manager.getEntities().indexOf(entityD, true));
+	}
+
+	@Test
+	public void removeAndAddEntityDelayed() {
+		EntityListenerMock listener = new EntityListenerMock();
+		EntityManager manager = new EntityManager(listener);
+
+		Entity entity = new Entity();
+		manager.addEntity(entity, false);     // immediate
+		assertEquals(1, manager.getEntities().size());
+
+		manager.removeEntity(entity, true);   // delayed
+		assertEquals(1, manager.getEntities().size());
+
+		manager.addEntity(entity, true);      // delayed
+		assertEquals(1, manager.getEntities().size());
+
+		manager.processPendingOperations();
+		assertEquals(1, manager.getEntities().size());
+	}
+
+	@Test
+	public void removeAllAndAddEntityDelayed() {
+		EntityListenerMock listener = new EntityListenerMock();
+		EntityManager manager = new EntityManager(listener);
+
+		Entity entity = new Entity();
+		manager.addEntity(entity, false);  // immediate
+		assertEquals(1, manager.getEntities().size());
+
+		manager.removeAllEntities(true);   // delayed
+		assertEquals(1, manager.getEntities().size());
+
+		manager.addEntity(entity, true);   // delayed
+		assertEquals(1, manager.getEntities().size());
+
+		manager.processPendingOperations();
+		assertEquals(1, manager.getEntities().size());
 	}
 }


### PR DESCRIPTION
The following code currently throws an exception because of duplicate entities:
    
    entityManager.addEntity(entity, false);     // immediate
    entityManager.removeEntity(entity, true);   // delayed
    entityManager.addEntity(entity, true);      // delayed.  Exception here!

This seems wrong.
