### PR TITLE
Split updating into updatePhysics, update and interpolate to make using a fixed timestep easier

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -20,6 +20,8 @@ import com.badlogic.ashley.core.ComponentOperationHandler.BooleanInformer;
 import com.badlogic.ashley.core.SystemManager.SystemListener;
 import com.badlogic.ashley.signals.Listener;
 import com.badlogic.ashley.signals.Signal;
+import com.badlogic.ashley.systems.InterpolatingSystem;
+import com.badlogic.ashley.systems.PhysicsSystem;
 import com.badlogic.ashley.utils.ImmutableArray;
 
 /**
@@ -188,6 +190,20 @@ public class Engine {
 		finally {
 			updating = false;
 		}	
+	}
+
+	public void updatePhysics(float physicsStep) {
+		ImmutableArray<PhysicsSystem> systems = systemManager.getPhysicsSystems();
+		for (PhysicsSystem system : systems) {
+			system.updatePhysics(physicsStep);
+		}
+	}
+
+	public void interpolate(float delta, float physicsStep, float inAccumulator) {
+		ImmutableArray<InterpolatingSystem> systems = systemManager.getInterpolatingSystems();
+		for (InterpolatingSystem system : systems) {
+			system.interpolate(delta, physicsStep, inAccumulator);
+		}
 	}
 	
 	protected void addEntityInternal(Entity entity) {

--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -192,6 +192,10 @@ public class Engine {
 		}	
 	}
 
+	/**
+	 * Updates all registered {@link PhysicsSystem}s. Should be used according to http://gafferongames.com/game-physics/fix-your-timestep/
+	 * @param physicsStep the physics step to use in the simulation, not the delta time, should be constant
+	 */
 	public void updatePhysics(float physicsStep) {
 		ImmutableArray<PhysicsSystem> systems = systemManager.getPhysicsSystems();
 		for (PhysicsSystem system : systems) {
@@ -199,6 +203,13 @@ public class Engine {
 		}
 	}
 
+	/**
+	 * Updates all registered {@link InterpolatingSystem}s. Should be used after a physics simulation with a fixed timestep,
+	 * see http://gafferongames.com/game-physics/fix-your-timestep/
+	 * @param delta	current delta time, sometimes necessary for some rendering
+	 * @param physicsStep the physics step used in the simulation, should be constant
+	 * @param inAccumulator what is left in the accumulator after performing possible physics step, should be < physicsStep
+	 */
 	public void interpolate(float delta, float physicsStep, float inAccumulator) {
 		ImmutableArray<InterpolatingSystem> systems = systemManager.getInterpolatingSystems();
 		for (InterpolatingSystem system : systems) {

--- a/ashley/src/com/badlogic/ashley/core/SystemManager.java
+++ b/ashley/src/com/badlogic/ashley/core/SystemManager.java
@@ -1,17 +1,21 @@
 package com.badlogic.ashley.core;
 
-import java.util.Comparator;
-
-import com.badlogic.ashley.signals.Listener;
-import com.badlogic.ashley.signals.Signal;
+import com.badlogic.ashley.systems.InterpolatingSystem;
+import com.badlogic.ashley.systems.PhysicsSystem;
 import com.badlogic.ashley.utils.ImmutableArray;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ObjectMap;
 
+import java.util.Comparator;
+
 class SystemManager {
 	private SystemComparator systemComparator = new SystemComparator();
 	private Array<EntitySystem> systems = new Array<EntitySystem>(false, 16);
+	private Array<PhysicsSystem> physicsSystems = new Array<PhysicsSystem>(false, 16);
+	private Array<InterpolatingSystem> interpolatingSystems = new Array<InterpolatingSystem>(false, 16);
 	private ImmutableArray<EntitySystem> immutableSystems = new ImmutableArray<EntitySystem>(systems);
+	private ImmutableArray<PhysicsSystem> immutablePhysicsSystems = new ImmutableArray<PhysicsSystem>(physicsSystems);
+	private ImmutableArray<InterpolatingSystem> immutableInterpolatingSystems = new ImmutableArray<InterpolatingSystem>(interpolatingSystems);
 	private ObjectMap<Class<?>, EntitySystem> systemsByClass = new ObjectMap<Class<?>, EntitySystem>();
 	private SystemListener listener;
 	
@@ -31,12 +35,25 @@ class SystemManager {
 		systemsByClass.put(systemType, system);		
 		systems.sort(systemComparator);
 		listener.systemAdded(system);
+
+		if (system instanceof PhysicsSystem) {
+			physicsSystems.add((PhysicsSystem) system);
+		}
+		if (system instanceof InterpolatingSystem) {
+			interpolatingSystems.add((InterpolatingSystem) system);
+		}
 	}
 	
 	public void removeSystem(EntitySystem system){
 		if(systems.removeValue(system, true)) {
 			systemsByClass.remove(system.getClass());
 			listener.systemRemoved(system);
+		}
+		if (system instanceof PhysicsSystem) {
+			physicsSystems.removeValue((PhysicsSystem) system, true);
+		}
+		if (system instanceof InterpolatingSystem) {
+			interpolatingSystems.removeValue((InterpolatingSystem) system, true);
 		}
 	}
 	
@@ -47,6 +64,14 @@ class SystemManager {
 	
 	public ImmutableArray<EntitySystem> getSystems() {
 		return immutableSystems;
+	}
+
+	public ImmutableArray<PhysicsSystem> getPhysicsSystems() {
+		return immutablePhysicsSystems;
+	}
+
+	public ImmutableArray<InterpolatingSystem> getInterpolatingSystems() {
+		return immutableInterpolatingSystems;
 	}
 	
 	private static class SystemComparator implements Comparator<EntitySystem>{

--- a/ashley/src/com/badlogic/ashley/systems/InterpolatingSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/InterpolatingSystem.java
@@ -1,6 +1,19 @@
 package com.badlogic.ashley.systems;
 
+import com.badlogic.ashley.core.Engine;
+import com.badlogic.ashley.core.EntitySystem;
+
+/**
+ * An {@link EntitySystem} that is meant to reduce temporal aliasing when using a fixed timestep for physics
+ * See http://gafferongames.com/game-physics/fix-your-timestep/ for explanation.
+ */
 public interface InterpolatingSystem {
 
+	/**
+	 * Will be called when {@link Engine#interpolate(float, float, float)} is called.
+	 * @param delta	current delta time, sometimes necessary for some rendering
+	 * @param physicsStep the physics step used in the simulation, should be constant
+	 * @param inAccumulator what is left in the accumulator after performing possible physics step, should be < physicsStep
+	 */
 	void interpolate(float delta, float physicsStep, float inAccumulator);
 }

--- a/ashley/src/com/badlogic/ashley/systems/InterpolatingSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/InterpolatingSystem.java
@@ -1,0 +1,6 @@
+package com.badlogic.ashley.systems;
+
+public interface InterpolatingSystem {
+
+	void interpolate(float delta, float physicsStep, float inAccumulator);
+}

--- a/ashley/src/com/badlogic/ashley/systems/PhysicsSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/PhysicsSystem.java
@@ -1,0 +1,6 @@
+package com.badlogic.ashley.systems;
+
+public interface PhysicsSystem {
+
+	void updatePhysics(float physicsStep);
+}

--- a/ashley/src/com/badlogic/ashley/systems/PhysicsSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/PhysicsSystem.java
@@ -1,6 +1,17 @@
 package com.badlogic.ashley.systems;
 
+import com.badlogic.ashley.core.Engine;
+import com.badlogic.ashley.core.EntitySystem;
+
+/**
+ * An {@link EntitySystem} that is meant for operations with a fixed timestep, like physics.
+ * See http://gafferongames.com/game-physics/fix-your-timestep/ for explanation.
+ */
 public interface PhysicsSystem {
 
+	/**
+	 * Will be called when {@link Engine#updatePhysics(float)} is called.
+	 * @param physicsStep the physics step to use in the simulation, not the delta time, should be constant
+	 */
 	void updatePhysics(float physicsStep);
 }


### PR DESCRIPTION
I tired to enhance Ashley to make it easier to apply the technique mentioned here: [http://gafferongames.com/game-physics/fix-your-timestep/](http://gafferongames.com/game-physics/fix-your-timestep/).

Now you can have this in your main loop:

``` java
accumulator += delta;
while (accumulator > PHYSICS_STEP) {
   engine.updatePhysics(PHYSICS_STEP);
   accumulator -= PHYSICS_STEP;
}
engine.update(delta);
engine.interpolate(delta, PHYSICS_STEP, accumulator);
```

Then you can use the PhysicsSystem and InterpolatingSystem interfaces to implement fixed timestep and interpolating behaviour.
