### PR TITLE
Added a new update method for updating only a certain range of systems

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -171,10 +171,10 @@ public class Engine {
 	}
 
 	/**
-	 * Updates all the systems with priorities in the range
+	 * Updates all the systems with priorities in the given range
 	 * @param deltaTime The time passed since the last frame.
-	 * @param minRange The lowest range to update, inclusive
-	 * @param maxRange The highest range to update, inclusive
+	 * @param minRange The lowest priority to update, inclusive
+	 * @param maxRange The highest priority to update, inclusive
 	 */
 	public void update(float deltaTime, int minRange, int maxRange){
 		if (updating) {

--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -189,6 +189,38 @@ public class Engine {
 			updating = false;
 		}	
 	}
+
+	/**
+	 * Updates all the systems with priorities in the range
+	 * @param deltaTime The time passed since the last frame.
+	 * @param minRange The lowest range to update, inclusive
+	 * @param maxRange The highest range to update, exclusive
+	 */
+	public void update(float deltaTime, int minRange, int maxRange){
+		if (updating) {
+			throw new IllegalStateException("Cannot call update() on an Engine that is already updating.");
+		}
+
+		updating = true;
+		ImmutableArray<EntitySystem> systems = systemManager.getSystems();
+		try {
+			for (int i = 0; i < systems.size(); ++i) {
+				EntitySystem system = systems.get(i);
+
+				if(system.priority >= minRange && system.priority <= maxRange) {
+					if (system.checkProcessing()) {
+						system.update(deltaTime);
+					}
+				}
+
+				componentOperationHandler.processOperations();
+				entityManager.processPendingOperations();
+			}
+		}
+		finally {
+			updating = false;
+		}
+	}
 	
 	protected void addEntityInternal(Entity entity) {
 		entity.componentAdded.add(componentAdded);

--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -207,7 +207,7 @@ public class Engine {
 			for (int i = 0; i < systems.size(); ++i) {
 				EntitySystem system = systems.get(i);
 
-				if(system.priority >= minRange && system.priority <= maxRange) {
+				if(system.priority >= minRange && system.priority < maxRange) {
 					if (system.checkProcessing()) {
 						system.update(deltaTime);
 					}

--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -167,34 +167,14 @@ public class Engine {
 	 * @param deltaTime The time passed since the last frame.
 	 */
 	public void update(float deltaTime){
-		if (updating) {
-			throw new IllegalStateException("Cannot call update() on an Engine that is already updating.");
-		}
-		
-		updating = true;
-		ImmutableArray<EntitySystem> systems = systemManager.getSystems();
-		try {
-			for (int i = 0; i < systems.size(); ++i) {
-				EntitySystem system = systems.get(i);
-				
-				if (system.checkProcessing()) {
-					system.update(deltaTime);
-				}
-	
-				componentOperationHandler.processOperations();
-				entityManager.processPendingOperations();
-			}
-		}
-		finally {
-			updating = false;
-		}	
+		update(deltaTime, Integer.MIN_VALUE, Integer.MAX_VALUE);
 	}
 
 	/**
 	 * Updates all the systems with priorities in the range
 	 * @param deltaTime The time passed since the last frame.
 	 * @param minRange The lowest range to update, inclusive
-	 * @param maxRange The highest range to update, exclusive
+	 * @param maxRange The highest range to update, inclusive
 	 */
 	public void update(float deltaTime, int minRange, int maxRange){
 		if (updating) {
@@ -207,7 +187,7 @@ public class Engine {
 			for (int i = 0; i < systems.size(); ++i) {
 				EntitySystem system = systems.get(i);
 
-				if(system.priority >= minRange && system.priority < maxRange) {
+				if(system.priority >= minRange && system.priority <= maxRange) {
 					if (system.checkProcessing()) {
 						system.update(deltaTime);
 					}

--- a/ashley/tests/com/badlogic/ashley/core/EngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EngineTests.java
@@ -298,6 +298,41 @@ public class EngineTests {
 	}
 
 	@Test
+	public void systemUpdateRanged() {
+		Engine engine = new Engine();
+		EntitySystemMock systemA = new EntitySystemMockA();
+		EntitySystemMock systemB = new EntitySystemMockB();
+
+		systemA.priority = 1;
+		systemB.priority = 2;
+
+		engine.addSystem(systemA);
+		engine.addSystem(systemB);
+
+		int numUpdates = 10;
+
+		for (int i = 0; i < numUpdates; ++i) {
+			assertEquals(i, systemA.updateCalls);
+			assertEquals(i, systemB.updateCalls);
+
+			engine.update(deltaTime, 1, 3);
+
+			assertEquals(i + 1, systemA.updateCalls);
+			assertEquals(i + 1, systemB.updateCalls);
+		}
+
+		for (int i = 0; i < numUpdates; ++i) {
+			assertEquals(i + numUpdates, systemA.updateCalls);
+			assertEquals(numUpdates, systemB.updateCalls);
+
+			engine.update(deltaTime, 1, 2);
+
+			assertEquals(i + 1 + numUpdates, systemA.updateCalls);
+			assertEquals(numUpdates, systemB.updateCalls);
+		}
+	}
+
+	@Test
 	public void systemUpdateOrder () {
 		Array<Integer> updates = new Array<Integer>();
 

--- a/ashley/tests/com/badlogic/ashley/core/EngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EngineTests.java
@@ -315,7 +315,7 @@ public class EngineTests {
 			assertEquals(i, systemA.updateCalls);
 			assertEquals(i, systemB.updateCalls);
 
-			engine.update(deltaTime, 1, 3);
+			engine.update(deltaTime, 1, 2);
 
 			assertEquals(i + 1, systemA.updateCalls);
 			assertEquals(i + 1, systemB.updateCalls);
@@ -325,7 +325,7 @@ public class EngineTests {
 			assertEquals(i + numUpdates, systemA.updateCalls);
 			assertEquals(numUpdates, systemB.updateCalls);
 
-			engine.update(deltaTime, 1, 2);
+			engine.update(deltaTime, 1, 1);
 
 			assertEquals(i + 1 + numUpdates, systemA.updateCalls);
 			assertEquals(numUpdates, systemB.updateCalls);


### PR DESCRIPTION
The new method allows users to update only systems with priorities in a certain range. These are still sorted by priority. The original update method now defers to this one with a full range.