### PR TITLE
Added addAndReturn for easier Component Manipulation

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Entity.java
+++ b/ashley/src/com/badlogic/ashley/core/Entity.java
@@ -75,6 +75,15 @@ public class Entity {
 	}
 
 	/**
+	 * Adds a {@link Component} to this Entity. If a {@link Component} of the same type already exists, it'll be replaced.
+	 * @return The Component for direct component manipulation (e.g. PooledComponent)
+	 */
+	public Component addAndReturn(Component component) {
+		add(component);
+		return component;
+	}
+
+	/**
 	 * Removes the {@link Component} of the specified type. Since there is only ever one component of one type, we don't need an
 	 * instance reference.
 	 * @return The removed {@link Component}, or null if the Entity did no contain such a component.

--- a/ashley/tests/com/badlogic/ashley/core/EntityTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EntityTests.java
@@ -53,6 +53,18 @@ public class EntityTests {
 	private ComponentMapper<ComponentB> bm = ComponentMapper.getFor(ComponentB.class);
 
 	@Test
+	public void addAndReturnComponent(){
+		Entity entity = new Entity();
+		ComponentA componentA = new ComponentA();
+		ComponentB componentB = new ComponentB();
+
+		assertEquals(componentA, entity.addAndReturn(componentA));
+		assertEquals(componentB, entity.addAndReturn(componentB));
+
+		assertEquals(2, entity.getComponents().size());
+	}
+
+	@Test
 	public void noComponents () {
 		Entity entity = new Entity();
 


### PR DESCRIPTION
Sometimes it is useful to return the Component instead of the Entity. Especially when using the Pooled Engine.

With the PooledEngine you can't use the Constructor of a Component to init its values. The Current API forces you to Keep a reference for every Component when you want to modify data in it when adding a new Entity.

This PR introduces the `addAndReturn(Compoment component)` Method so you can write something like that:

`
entity.addAndReturn(pooledEngine.createComponent(ComponentA.class)).set(data1, data2)
`

Where `set()` is a method that sets the data of the component. That is much more convenient than

```
ComponentA componentA = pooledEngine.createComponent(ComponentA.class);
componentA.set(data1, data2);
entity.add(componentA);
```

Especially when dealing with a lot of components.

I also added a unitTest case for that Method which passes. It also won't break existing API behaviour.
