### PR TITLE
Adds createEntity method to Engine

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -53,7 +53,7 @@ public class Engine {
 	/**
 	 * Creates a new Entity object.
 	 * @return @{@link Entity}
-     */
+	 */
 
 	public Entity createEntity () {
 		return new Entity();

--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -50,6 +50,14 @@ public class Engine {
 	private FamilyManager familyManager = new FamilyManager(entityManager.getEntities());	
 	private boolean updating;
 
+	/**
+	 * Creates a new Entity object.
+	 * @return @{@link Entity}
+     */
+
+	public Entity createEntity () {
+		return new Entity();
+	}
 
 	/**
 	 * Adds an entity to this Engine.

--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -60,7 +60,8 @@ public class PooledEngine extends Engine {
 		componentPools = new ComponentPools(componentPoolInitialSize, componentPoolMaxSize);
 	}
 
-	/** @return Clean {@link Entity} from the Engine pool. In order to add it to the {@link Engine}, use {@link #addEntity(Entity)}. */
+	/** @return Clean {@link Entity} from the Engine pool. In order to add it to the {@link Engine}, use {@link #addEntity(Entity)}. @{@link Override {@link Engine#createEntity()}} */
+	@Override
 	public Entity createEntity () {
 		return entityPool.obtain();
 	}

--- a/ashley/tests/com/badlogic/ashley/core/EngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EngineTests.java
@@ -833,4 +833,13 @@ public class EngineTests {
 		
 		engine.update(0.0f);
 	}
+
+	@Test
+	public void createNewEntity () {
+		Engine engine = new Engine();
+		Entity entity = engine.createEntity();
+
+		assertNotEquals(entity, null);
+	}
+
 }


### PR DESCRIPTION
Just a simple method present in Engine class which returns a new Entity
instance. Its usefulness arises when retrieving PooledEngine from
their EntitySystem in order to create new entities. Since PooledEngine
now inherits and overrides createEntity function, castings from Engine
to PooledEngine are no longer required. On the other hand, a trivial
test has been added.