### PR TITLE
Added a configurations map to the engine

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Configuration.java
+++ b/ashley/src/com/badlogic/ashley/core/Configuration.java
@@ -1,0 +1,7 @@
+package com.badlogic.ashley.core;
+
+/**An interface for Objects that need to perform operations when added to or removed from the engine's configurations*/
+	public interface Configuration {
+		public boolean onAdd(Engine engine);
+		public boolean onRemove(Engine engine);
+}

--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -22,6 +22,7 @@ import com.badlogic.ashley.signals.Listener;
 import com.badlogic.ashley.signals.Signal;
 import com.badlogic.ashley.utils.ImmutableArray;
 import com.badlogic.gdx.utils.ObjectMap;
+import com.badlogic.gdx.utils.ObjectMap.Entries;
 import com.badlogic.gdx.utils.ObjectMap.Keys;
 import com.badlogic.gdx.utils.ObjectMap.Values;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
@@ -191,10 +192,23 @@ public class Engine {
 		familyManager.removeEntityListener(listener);
 	}
 
+	/**
+	 * Retrieves the configuration item associated with that class
+	 */
 	public <T> T getConfiguration(Class<T> clazz) {
 		return (T) configurations.get(clazz);
 	}
 
+	/**
+	 * Retrieves an iterator for the configuration entries 
+	 */
+	public Entries<Class, Object> getConfigurationEntries() {
+		return configurations.entries();
+	}
+	
+	/**
+	 * Retrieves all stored configurations
+	 */
 	public Object[] getConfigurations() {
 		Object[] configs = new Object[configurations.size];
 		Values values = configurations.values();
@@ -204,6 +218,9 @@ public class Engine {
 		return configs;
 	}
 
+	/**
+	 * Adds a configuration to the engine
+	 */
 	public <T> T addConfiguration(Class<T> clazz, T configuration) {
 		if (configuration instanceof Configuration)
 			((Configuration) configuration).onAdd(this);
@@ -216,6 +233,9 @@ public class Engine {
 		return result;
 	}
 
+	/**
+	 * Removes a configuration from the engine 
+	 */
 	public Object removeConfiguration(Class<? extends Object> clazz) {
 		Object config = configurations.get(clazz);
 		if (config == null)
@@ -229,6 +249,17 @@ public class Engine {
 
 	}
 
+	/**
+	 * Removes a configuration from the engine returns the class that the configuration was associated to
+	 */
+	public Class removeConfiguration(Object configuration) {
+		Class configType = configurations.findKey(configuration, true);
+		if (configType == null)
+			return null;
+		removeConfiguration(configType);
+		return configType;
+	}
+
 	Class[] getConfigurationKeys() {
 		Class[] result = new Class[configurations.size];
 		Keys<Class> keys = configurations.keys();
@@ -237,6 +268,9 @@ public class Engine {
 		return result;
 	}
 
+	/**
+	 * Removes all configurations from the engine
+	 */
 	public void clearConfigurations() {
 		for (Class key : getConfigurationKeys()) {
 			removeConfiguration(key);

--- a/ashley/tests/com/badlogic/ashley/core/ConfigurationTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/ConfigurationTests.java
@@ -1,0 +1,49 @@
+package com.badlogic.ashley.core;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class ConfigurationTests {
+
+	@Test
+	public void addAndRemoveConfigurations(){
+		Engine engine=new Engine();
+		ConfigurationImpl conf=new ConfigurationImpl();
+		engine.addConfiguration(ConfigurationImpl.class,conf);
+		assertTrue(conf.added);
+		assertTrue(engine.getConfiguration(ConfigurationImpl.class)==conf);
+		engine.removeConfiguration(ConfigurationImpl.class);
+		assertTrue(conf.removed);
+		assertTrue(engine.getConfiguration(ConfigurationImpl.class)==null);
+	}
+	
+	@Test
+	public void clearConfigurations(){
+			Engine engine=new Engine();
+			ConfigurationImpl conf=new ConfigurationImpl();
+			engine.addConfiguration(ConfigurationImpl.class,conf);
+			assertTrue(conf.added);
+			engine.clearConfigurations();
+			assertTrue(conf.removed);
+			assertTrue(engine.getConfiguration(ConfigurationImpl.class)==null);
+	}
+
+	static class ConfigurationImpl implements Configuration {
+
+		boolean added = false;
+		boolean removed = false;
+
+		@Override
+		public boolean onAdd(Engine engine) {
+			added = true;
+			return false;
+		}
+
+		@Override
+		public boolean onRemove(Engine engine) {
+			removed = true;
+			return false;
+		}
+
+	}
+}

--- a/ashley/tests/com/badlogic/ashley/core/ConfigurationTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/ConfigurationTests.java
@@ -3,45 +3,91 @@ package com.badlogic.ashley.core;
 import static org.junit.Assert.*;
 import org.junit.Test;
 
+import com.badlogic.ashley.signals.Listener;
+import com.badlogic.ashley.signals.Signal;
+
 public class ConfigurationTests {
 
 	@Test
-	public void addAndRemoveConfigurations(){
-		Engine engine=new Engine();
-		ConfigurationImpl conf=new ConfigurationImpl();
-		engine.addConfiguration(ConfigurationImpl.class,conf);
-		assertTrue(conf.added);
-		assertTrue(engine.getConfiguration(ConfigurationImpl.class)==conf);
+	public void addAndRemoveConfigurations() {
+		//Setup
+		Engine engine = new Engine();
+		ConfigurationImpl conf = new ConfigurationImpl();
+		//Test add
+		engine.addConfiguration(ConfigurationImpl.class, conf);
+		//Check it's been added
+		assertTrue(engine.getConfiguration(ConfigurationImpl.class) == conf);
+		//Check OnAdded has been called
+		assertTrue(conf.addCount==1);
+		//Test removal by key
 		engine.removeConfiguration(ConfigurationImpl.class);
-		assertTrue(conf.removed);
-		assertTrue(engine.getConfiguration(ConfigurationImpl.class)==null);
+		//Check it's been removed
+		assertTrue(engine.getConfiguration(ConfigurationImpl.class) == null);
+		//Check OnRemoved has been called
+		assertTrue(conf.removeCount==1);
+		//Setup
+		engine.addConfiguration(ConfigurationImpl.class, conf);
+		//Test removal by value
+		engine.removeConfiguration(conf);
+		//Check it's been removed
+		assertTrue(engine.getConfiguration(ConfigurationImpl.class) == null);
+		//Check OnRemoved has been called
+		assertTrue(conf.removeCount==2);
+	}
+
+	@Test
+	public void clearConfigurations() {
+		//Setup
+		Engine engine = new Engine();
+		ConfigurationImpl conf = new ConfigurationImpl();
+		engine.addConfiguration(ConfigurationImpl.class, conf);
+		//Test clear
+		engine.clearConfigurations();
+		//Check it's been removed
+		assertTrue(engine.getConfiguration(ConfigurationImpl.class) == null);
+		//Check OnRemoved has been called
+		assertTrue(conf.removeCount==1);
+	}
+
+	@Test
+	public void testListeners() {
+		//Setup
+		Engine engine = new Engine();
+		ConfigurationImpl conf = new ConfigurationImpl();
+		ConfigurationListenerImpl addListener=new ConfigurationListenerImpl();
+		ConfigurationListenerImpl removeListener=new ConfigurationListenerImpl();
+		engine.configurationAdded.add(addListener);
+		engine.configurationRemoved.add(removeListener);
+		//Add/Remove configuration
+		engine.addConfiguration(ConfigurationImpl.class, conf);
+		engine.removeConfiguration(ConfigurationImpl.class);
+		//Check the listeners have been called
+		assertTrue(addListener.callCount==1);
+		assertTrue(removeListener.callCount==1);
 	}
 	
-	@Test
-	public void clearConfigurations(){
-			Engine engine=new Engine();
-			ConfigurationImpl conf=new ConfigurationImpl();
-			engine.addConfiguration(ConfigurationImpl.class,conf);
-			assertTrue(conf.added);
-			engine.clearConfigurations();
-			assertTrue(conf.removed);
-			assertTrue(engine.getConfiguration(ConfigurationImpl.class)==null);
-	}
+	static class ConfigurationListenerImpl implements Listener<Object>{
+		int callCount=0;
+		@Override
+		public void receive(Signal<Object> signal, Object object) {
+			callCount++;
+			
+		}}
 
 	static class ConfigurationImpl implements Configuration {
 
-		boolean added = false;
-		boolean removed = false;
+		int addCount = 0;
+		int removeCount = 0;
 
 		@Override
 		public boolean onAdd(Engine engine) {
-			added = true;
+			addCount++;
 			return false;
 		}
 
 		@Override
 		public boolean onRemove(Engine engine) {
-			removed = true;
+			removeCount++;
 			return false;
 		}
 


### PR DESCRIPTION
Very often I find that I need to share data across multiple systems, such as a SpriteBatch, an asset manager, a serialization component or the Box2D World, so I created a map in the engine to store these "configuration" items. This also allows systems to autoconfigure themselves by retrieving the data when added to the engine. It also allows systems to keep track of changes in configurations with the use of signals and listeners. If you like the idea, feel free to accept this pull request.
