### PR TITLE
Added methods to remove all entities of a family

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -89,6 +89,14 @@ public class Engine {
 		boolean delayed = updating || familyManager.notifying();
 		entityManager.removeEntity(entity, delayed);
 	}
+	
+	/**
+	 * Removes all entities of the given {@link Family}.
+	 */
+	public void removeAllEntities(Family family) {
+		boolean delayed = updating || familyManager.notifying();
+		entityManager.removeAllEntities(getEntitiesFor(family), delayed);
+	}
 
 	/**
 	 * Removes all entities registered with this Engine.

--- a/ashley/src/com/badlogic/ashley/core/EntityManager.java
+++ b/ashley/src/com/badlogic/ashley/core/EntityManager.java
@@ -55,20 +55,29 @@ class EntityManager {
 	}
 	
 	public void removeAllEntities() {
-		removeAllEntities(false);
+		removeAllEntities(immutableEntities);
 	}
 	
 	public void removeAllEntities(boolean delayed) {
+		removeAllEntities(immutableEntities, delayed);
+	}
+	
+	public void removeAllEntities(ImmutableArray<Entity> entities) {
+		removeAllEntities(entities, false);
+	}
+
+	public void removeAllEntities(ImmutableArray<Entity> entities, boolean delayed) {
 		if (delayed) {
 			for(Entity entity: entities) {
 				entity.scheduledForRemoval = true;
 			}
 			EntityOperation operation = entityOperationPool.obtain();
 			operation.type = EntityOperation.Type.RemoveAll;
+			operation.entities = entities;
 			pendingOperations.add(operation);
 		}
 		else {
-			while(entities.size > 0) {
+			while(entities.size() > 0) {
 				removeEntity(entities.first(), false);
 			}
 		}
@@ -86,8 +95,8 @@ class EntityManager {
 				case Add: addEntityInternal(operation.entity); break;
 				case Remove: removeEntityInternal(operation.entity); break;
 				case RemoveAll:
-					while(entities.size > 0) {
-						removeEntityInternal(entities.first());
+					while(operation.entities.size() > 0) {
+						removeEntityInternal(operation.entities.first());
 					}
 					break;
 				default:
@@ -132,6 +141,7 @@ class EntityManager {
 
 		public Type type;
 		public Entity entity;
+		public ImmutableArray<Entity> entities;
 
 		@Override
 		public void reset() {

--- a/ashley/tests/com/badlogic/ashley/core/EngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EngineTests.java
@@ -739,6 +739,22 @@ public class EngineTests {
 		assertEquals(1, listenerB.removedCount);
 
 		engine.addEntityListener(listenerB);
+
+		engine.addEntity(entity1);
+		engine.addEntity(entity2);
+
+		assertEquals(3, listenerA.addedCount);
+		assertEquals(3, listenerB.addedCount);
+		
+		engine.removeAllEntities(familyA);
+
+		assertEquals(3, listenerA.removedCount);
+		assertEquals(2, listenerB.removedCount);
+		
+		engine.removeAllEntities(familyB);
+
+		assertEquals(3, listenerA.removedCount);
+		assertEquals(3, listenerB.removedCount);
 	}
 
 	@Test


### PR DESCRIPTION
- Created necessary methods in `Engine` and `EntityManager`.
- Refactored the previous `removeAllEntities` methods to prevent code duplication.
- Added the attribute `entities` to `EntityOperation`
    - If the operation type is `Add` or `Remove` `entity` has a value and `entities` is null
    - If the operation type is `RemoveAll` `entities` has a value and `entity` is null
    - The attribute `entity` could be removed, so that `entities` would allways contain a single or multiple elements. With this, the operation type `RemoveAll` would be obsolete, since `processPendingOperations` would just loop over all elements and perform the corresponding operation for the current entity. But this would require more changes in the `EntityManager` that I'm currently comfortable with. Therefore the quick and dirty adjustment in `EntityOperation`
- Adjusted the `EngineTests.familyListener()` to test `Engine.removeAllEntities(Family)`. Seemed like the best place for this.