### PR TITLE
fix cascade operations in listeners while updating

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/ComponentOperationHandler.java
+++ b/ashley/src/com/badlogic/ashley/core/ComponentOperationHandler.java
@@ -35,6 +35,10 @@ class ComponentOperationHandler {
 		}
 	}
 	
+	public boolean hasOperationsToProcess() {
+		return operations.size > 0;
+	}
+	
 	public void processOperations() {
 		for (int i = 0; i < operations.size; ++i) {
 			ComponentOperation operation = operations.get(i);

--- a/ashley/src/com/badlogic/ashley/core/Engine.java
+++ b/ashley/src/com/badlogic/ashley/core/Engine.java
@@ -225,8 +225,10 @@ public class Engine {
 					system.update(deltaTime);
 				}
 	
-				componentOperationHandler.processOperations();
-				entityManager.processPendingOperations();
+				while(componentOperationHandler.hasOperationsToProcess() || entityManager.hasPendingOperations()) {
+					componentOperationHandler.processOperations();
+					entityManager.processPendingOperations();
+				}
 			}
 		}
 		finally {

--- a/ashley/src/com/badlogic/ashley/core/EntityManager.java
+++ b/ashley/src/com/badlogic/ashley/core/EntityManager.java
@@ -78,6 +78,10 @@ class EntityManager {
 		return immutableEntities;
 	}
 	
+	public boolean hasPendingOperations() {
+		return pendingOperations.size > 0;
+	}
+	
 	public void processPendingOperations() {
 		for (int i = 0; i < pendingOperations.size; ++i) {
 			EntityOperation operation = pendingOperations.get(i); 


### PR DESCRIPTION
Use case which illustrates the problem : 

* I have Entity A following Entity B. Entity A has a Follow component which store a reference to entity B. 
* I have a LifeSystem checking entities life and remove them when destroyed.
* I have a FollowSystem updating entity A position from entity B position.
* When entity B is destroyed by LifeSystem, Follow component is removed from entity A (this is made by an entity listener).
* When FollowSystem update occurs, entity A still in Follow Family but it no longer have Follow component on it.

This PR fixes this particular use case but other use cases where listeners remove/add components and/or entities which cause a cascade of events.

Note : in my use case, `componentOperationHandler.processOperations();` need to be called again after `entityManager.processPendingOperations();` but in some other situations, both methods needs to be called several times until no operations have to be processed.