### PR TITLE
#263 Reset pooled components when replacing

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Entity.java
+++ b/ashley/src/com/badlogic/ashley/core/Entity.java
@@ -95,7 +95,7 @@ public class Entity {
 		if(components.isIndexWithinBounds(componentTypeIndex)){
 			Component removeComponent = components.get(componentTypeIndex);
 	
-			if (removeComponent != null && removeInternal(componentClass)) {
+			if (removeComponent != null && removeInternal(componentClass) != null) {
 				if (componentOperationHandler != null) {
 					componentOperationHandler.remove(this);
 				}
@@ -194,9 +194,9 @@ public class Entity {
 
 	/**
 	 * @param componentClass
-	 * @return whether or not a component with the specified class was found and removed.
+	 * @return the component if the specified class was found and removed. Otherwise, null
 	 */
-	boolean removeInternal (Class<? extends Component> componentClass) {
+	Component removeInternal (Class<? extends Component> componentClass) {
 		ComponentType componentType = ComponentType.getFor(componentClass);
 		int componentTypeIndex = componentType.getIndex();
 		Component removeComponent = components.get(componentTypeIndex);
@@ -206,10 +206,10 @@ public class Entity {
 			componentsArray.removeValue(removeComponent, true);
 			componentBits.clear(componentTypeIndex);
 			
-			return true;
+			return removeComponent;
 		}
-		
-		return false;
+
+		return null;
 	}
 	
 	void notifyComponentAdded() {

--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -107,6 +107,16 @@ public class PooledEngine extends Engine {
 		}
 
 		@Override
+		Component removeInternal(Class<? extends Component> componentClass) {
+			Component removed = super.removeInternal(componentClass);
+			if (removed != null) {
+				componentPools.free(removed);
+			}
+
+			return removed;
+		}
+
+		@Override
 		public void reset () {
 			removeAll();
 			flags = 0;

--- a/ashley/tests/com/badlogic/ashley/core/PooledEngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/PooledEngineTests.java
@@ -14,8 +14,18 @@ import com.badlogic.gdx.utils.Pool.Poolable;
 public class PooledEngineTests {
 	private float deltaTime = 0.16f;
 
+	private final ComponentMapper<PoolableComponent> poolableMapper = ComponentMapper.getFor(PoolableComponent.class);
+
 	public static class ComponentA implements Component {
 		public ComponentA(){}
+	}
+
+	public static class PoolableComponent implements Component, Poolable {
+		boolean reset = true;
+		@Override
+		public void reset() {
+			reset = true;
+		}
 	}
 
 	public static class PositionComponent implements Component {
@@ -243,5 +253,26 @@ public class PooledEngineTests {
 		ComponentA componentA = engine.createComponent(ComponentA.class);
 
 		assertNotNull(componentA);
+	}
+
+	@Test
+	public void addSameComponentShouldResetAndReturnOldComponentToPool () {
+		PooledEngine engine = new PooledEngine();
+
+		PoolableComponent component1 = engine.createComponent(PoolableComponent.class);
+		component1.reset = false;
+		PoolableComponent component2 = engine.createComponent(PoolableComponent.class);
+		component2.reset = false;
+
+		Entity entity = engine.createEntity();
+		entity.add(component1);
+		entity.add(component2);
+
+		assertEquals(1, entity.getComponents().size());
+		assertTrue(poolableMapper.has(entity));
+		assertNotEquals(component1, poolableMapper.get(entity));
+		assertEquals(component2, poolableMapper.get(entity));
+
+		assertTrue(component1.reset);
 	}
 }


### PR DESCRIPTION
Attempted fix for #263 where adding a Poolable component that replaces an existing component does not call `reset()` or return it to the pool.

This change modifies the return type of the package-private `removeInternal` so may potentially break client code that is using it.