### PR TITLE
Entity#addAndReturn(Component) and Entity#remove(Class) generified

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/Entity.java
+++ b/ashley/src/com/badlogic/ashley/core/Entity.java
@@ -78,7 +78,7 @@ public class Entity {
 	 * Adds a {@link Component} to this Entity. If a {@link Component} of the same type already exists, it'll be replaced.
 	 * @return The Component for direct component manipulation (e.g. PooledComponent)
 	 */
-	public Component addAndReturn(Component component) {
+	public <T extends Component> T addAndReturn(T component) {
 		add(component);
 		return component;
 	}

--- a/ashley/src/com/badlogic/ashley/core/Entity.java
+++ b/ashley/src/com/badlogic/ashley/core/Entity.java
@@ -86,9 +86,9 @@ public class Entity {
 	/**
 	 * Removes the {@link Component} of the specified type. Since there is only ever one component of one type, we don't need an
 	 * instance reference.
-	 * @return The removed {@link Component}, or null if the Entity did no contain such a component.
+	 * @return The removed {@link Component}, or null if the Entity did not contain such a component.
 	 */
-	public Component remove (Class<? extends Component> componentClass) {
+	public <T extends Component> T remove (Class<T> componentClass) {
 		ComponentType componentType = ComponentType.getFor(componentClass);
 		int componentTypeIndex = componentType.getIndex();
 		
@@ -104,7 +104,7 @@ public class Entity {
 				}
 			}
 	
-			return removeComponent;
+			return (T) removeComponent;
 		}
 		
 		return null;

--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -96,14 +96,14 @@ public class PooledEngine extends Engine {
 
 	private class PooledEntity extends Entity implements Poolable {
 		@Override
-		public Component remove (Class<? extends Component> componentClass) {
+		public <T extends Component> T remove (Class<T> componentClass) {
 			Component component = super.remove(componentClass);
 
 			if (component != null) {
 				componentPools.free(component);
 			}
 
-			return component;
+			return (T) component;
 		}
 
 		@Override

--- a/ashley/tests/com/badlogic/ashley/core/EntityTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EntityTests.java
@@ -65,6 +65,12 @@ public class EntityTests {
 	}
 
 	@Test
+	public void addAndReturnComponentGeneric () {
+		Entity entity = new Entity();
+		ComponentA componentA = entity.addAndReturn(new ComponentA());
+	}
+
+	@Test
 	public void noComponents () {
 		Entity entity = new Entity();
 


### PR DESCRIPTION
* `addAndReturn` should not require an additional cast to the concrete component class