### PR TITLE
Only free a component once in `removeInternal`

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -96,17 +96,6 @@ public class PooledEngine extends Engine {
 
 	private class PooledEntity extends Entity implements Poolable {
 		@Override
-		public Component remove (Class<? extends Component> componentClass) {
-			Component component = super.remove(componentClass);
-
-			if (component != null) {
-				componentPools.free(component);
-			}
-
-			return component;
-		}
-
-		@Override
 		Component removeInternal(Class<? extends Component> componentClass) {
 			Component removed = super.removeInternal(componentClass);
 			if (removed != null) {

--- a/ashley/tests/com/badlogic/ashley/core/PooledEngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/PooledEngineTests.java
@@ -275,4 +275,21 @@ public class PooledEngineTests {
 
 		assertTrue(component1.reset);
 	}
+
+	@Test
+	public void removeComponentReturnsItToThePoolExactlyOnce() {
+		PooledEngine engine = new PooledEngine();
+
+		PoolableComponent removedComponent = engine.createComponent(PoolableComponent.class);
+
+		Entity entity = engine.createEntity();
+		entity.add(removedComponent);
+
+		entity.remove(PoolableComponent.class);
+
+		PoolableComponent newComponent1 = engine.createComponent(PoolableComponent.class);
+		PoolableComponent newComponent2 = engine.createComponent(PoolableComponent.class);
+
+		assertNotEquals(newComponent1, newComponent2);
+	}
 }


### PR DESCRIPTION
@saltares This fixes a bug when calling `Entity.remove(Component)` that would free the component twice (once in `remove` and once in `removeInternal`) resulting in the component object appearing twice in the object pool.

