### PR TITLE
Update gradle to 5.4 and libgdx to 1.9.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ subprojects {
 
 ext {
     projectGroup = "ashley"
-    gdxVersion = "1.9.4"
+    gdxVersion = "1.9.9"
     jUnitVersion = "4.12"
     mockitoVersion = "1.10.19"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-5.4-all.zip


### PR DESCRIPTION
gradle 1.10 is no more supported by IntelliJ (version 2019).
So the update to the newest version of Gradle is mandatory.