### PR TITLE
use proper generic parameter, fixes #278

### DIFF
--- a/ashley/src/com/badlogic/ashley/utils/ImmutableArray.java
+++ b/ashley/src/com/badlogic/ashley/utils/ImmutableArray.java
@@ -70,7 +70,7 @@ public class ImmutableArray<T> implements Iterable<T> {
 		return array.toArray();
 	}
 
-	public <V> V[] toArray (Class<?> type) {
+	public <V> V[] toArray (Class<V> type) {
 		return array.toArray(type);
 	}
 	


### PR DESCRIPTION
GWT version (2.8.2) is now the default for new libgdx projects and it seams to complain about generic stuff.

This code is closed libgdx Array which was modified before GWT migration [see this commit](https://github.com/libgdx/libgdx/commit/788b95f4388638d2ef9a5909136622e35bc4da95#diff-df2fbb0780aad20f61d6603c86644aa9)

I didn't deeply tested Ashley with GWT 2.8.2, i only compiled a project using Ashley with this fix and run my project (calling new Engine and new ImmutableArray just to be sure). All worked fine so far and i'm pretty confident with this fix.

Maybe #278 people could try it : 
* clone ashley locally
* pull this PR
* install locally : `gradlew install`
* use ashley 1.7.4 in your project
* build and run your HTML module