### PR TITLE
IntervalSystem remove final modifier on update(dt) method

### DIFF
--- a/ashley/src/com/badlogic/ashley/systems/IntervalSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/IntervalSystem.java
@@ -49,7 +49,7 @@ public abstract class IntervalSystem extends EntitySystem {
 	}
 
 	@Override
-	public final void update (float deltaTime) {
+	public void update (float deltaTime) {
 		accumulator += deltaTime;
 
 		while (accumulator >= interval) {


### PR DESCRIPTION
Hello, the final modifier on update method is blocking for extends this classes.

My problem is i want call some code before and after each update on  all systems.

The class Engine and PooledEngine are not extensible cause many internal fields , i see this issues on this problem  [https://github.com/libgdx/ashley/issues/255](url) 

The only method i found is too extends all Systems classes and add my code and do super.update(dt) 

I understand the logic behind this final modifier. But he is blocking for extends.

An other solution can be do with the classes Engine and PooledEngine, but its big modification. 

Thanks for reading 