### PR TITLE
Update libGDX to 1.10.0 and Java Source to 1.7 and create utility functions for iterating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ and transparent to use.
 
 Ashley is awesome, if you don't believe it, check out some [games](https://github.com/libgdx/ashley/wiki/Games-made-with-Ashley) made with it!
 
-Ashley lives under the [Libgdx](https://github.com/libgdx) family but it does not force you to use that specific framework if you do not wish to do so.
+Ashley lives under the [libGDX](https://github.com/libgdx) family but it does not force you to use that specific framework if you do not wish to do so.
 
-Libgdx Discord : [![Discord Chat](https://img.shields.io/discord/348229412858101762?logo=discord)](https://libgdx.com/community/discord/)
+libGDX Discord : [![Discord Chat](https://img.shields.io/discord/348229412858101762?logo=discord)](https://libgdx.com/community/discord/)
 
 ### Get started
 
@@ -28,7 +28,7 @@ Libgdx Discord : [![Discord Chat](https://img.shields.io/discord/348229412858101
 
 ### News and community
 
-Stay up to date in Ashley matters by following [@d_saltares](https://twitter.com/d_saltares) and reading [saltares.com](http://saltares.com). Check the [libgdx](https://libgdx.com/) blog as well for additional updates.
+Stay up to date in Ashley matters by following [@d_saltares](https://twitter.com/d_saltares) and reading [saltares.com](http://saltares.com). Check the [libGDX](https://libgdx.com/) blog as well for additional updates.
 
 ### Report issues
 

--- a/ashley/build.gradle
+++ b/ashley/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: "java"
-sourceCompatibility = 1.6
+sourceCompatibility = 1.7
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = [ "src/" ]

--- a/ashley/src/com/badlogic/ashley/systems/IntervalIteratingSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/IntervalIteratingSystem.java
@@ -87,11 +87,11 @@ public abstract class IntervalIteratingSystem extends IntervalSystem {
 	 * This method is called once on every update call of the EntitySystem, before entity processing begins. Override this method to
 	 * implement your specific startup conditions.
 	 */
-	public abstract void startProcessing();
+	public void startProcessing() {}
 
 	/**
 	 * This method is called once on every update call of the EntitySystem after entity processing is complete. Override this method to
 	 * implement your specific end conditions.
 	 */
-	public abstract void endProcessing();
+	public void endProcessing() {}
 }

--- a/ashley/src/com/badlogic/ashley/systems/IntervalIteratingSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/IntervalIteratingSystem.java
@@ -56,9 +56,11 @@ public abstract class IntervalIteratingSystem extends IntervalSystem {
 
 	@Override
 	protected void updateInterval () {
+		startProcessing();
 		for (int i = 0; i < entities.size(); ++i) {
 			processEntity(entities.get(i));
 		}
+		endProcessing();
 	}
 
 	/**
@@ -80,4 +82,16 @@ public abstract class IntervalIteratingSystem extends IntervalSystem {
 	 * @param entity
 	 */
 	protected abstract void processEntity (Entity entity);
+
+	/**
+	 * This method is called once on every update call of the EntitySystem, before entity processing begins. Override this method to
+	 * implement your specific startup conditions.
+	 */
+	public abstract void startProcessing();
+
+	/**
+	 * This method is called once on every update call of the EntitySystem after entity processing is complete. Override this method to
+	 * implement your specific end conditions.
+	 */
+	public abstract void endProcessing();
 }

--- a/ashley/src/com/badlogic/ashley/systems/IteratingSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/IteratingSystem.java
@@ -62,9 +62,11 @@ public abstract class IteratingSystem extends EntitySystem {
 
 	@Override
 	public void update (float deltaTime) {
+		startProcessing();
 		for (int i = 0; i < entities.size(); ++i) {
 			processEntity(entities.get(i), deltaTime);
 		}
+		endProcessing();
 	}
 
 	/**
@@ -88,4 +90,16 @@ public abstract class IteratingSystem extends EntitySystem {
 	 * @param deltaTime The delta time between the last and current frame
 	 */
 	protected abstract void processEntity (Entity entity, float deltaTime);
+
+	/**
+	 * This method is called once on every update call of the EntitySystem, before entity processing begins. Override this method to
+	 * implement your specific startup conditions.
+	 */
+	public void startProcessing() {}
+
+	/**
+	 * This method is called once on every update call of the EntitySystem after entity processing is complete. Override this method to
+	 * implement your specific end conditions.
+	 */
+	public void endProcessing() {}
 }

--- a/ashley/src/com/badlogic/ashley/systems/SortedIteratingSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/SortedIteratingSystem.java
@@ -147,11 +147,11 @@ public abstract class SortedIteratingSystem extends EntitySystem implements Enti
 	 * This method is called once on every update call of the EntitySystem, before entity processing begins. Override this method to
 	 * implement your specific startup conditions.
 	 */
-	public abstract void startProcessing();
+	public void startProcessing() {}
 
 	/**
 	 * This method is called once on every update call of the EntitySystem after entity processing is complete. Override this method to
 	 * implement your specific end conditions.
 	 */
-	public abstract void endProcessing();
+	public void endProcessing() {}
 }

--- a/ashley/src/com/badlogic/ashley/systems/SortedIteratingSystem.java
+++ b/ashley/src/com/badlogic/ashley/systems/SortedIteratingSystem.java
@@ -113,9 +113,11 @@ public abstract class SortedIteratingSystem extends EntitySystem implements Enti
 	@Override
 	public void update (float deltaTime) {
 		sort();
+		startProcessing();
 		for (int i = 0; i < sortedEntities.size; ++i) {
 			processEntity(sortedEntities.get(i), deltaTime);
 		}
+		endProcessing();
 	}
 
 	/**
@@ -140,4 +142,16 @@ public abstract class SortedIteratingSystem extends EntitySystem implements Enti
 	 * @param deltaTime The delta time between the last and current frame
 	 */
 	protected abstract void processEntity (Entity entity, float deltaTime);
+
+	/**
+	 * This method is called once on every update call of the EntitySystem, before entity processing begins. Override this method to
+	 * implement your specific startup conditions.
+	 */
+	public abstract void startProcessing();
+
+	/**
+	 * This method is called once on every update call of the EntitySystem after entity processing is complete. Override this method to
+	 * implement your specific end conditions.
+	 */
+	public abstract void endProcessing();
 }

--- a/ashley/src/com/badlogic/ashley/utils/ImmutableArray.java
+++ b/ashley/src/com/badlogic/ashley/utils/ImmutableArray.java
@@ -30,6 +30,10 @@ public class ImmutableArray<T> implements Iterable<T> {
 	private final Array<T> array;
 	private ArrayIterable<T> iterable;
 
+	public ImmutableArray() {
+		this(new Array<T>());
+	}
+
 	public ImmutableArray (Array<T> array) {
 		this.array = array;
 	}

--- a/ashley/tests/com/badlogic/ashley/systems/IntervalIteratingTest.java
+++ b/ashley/tests/com/badlogic/ashley/systems/IntervalIteratingTest.java
@@ -36,6 +36,9 @@ public class IntervalIteratingTest {
 
 	private static class IntervalIteratingSystemSpy extends IntervalIteratingSystem {
 		private ComponentMapper<IntervalComponentSpy> im;
+		public int numStartProcessing;
+		public int numEndProcessing;
+
 
 		public IntervalIteratingSystemSpy () {
 			super(Family.all(IntervalComponentSpy.class).get(), deltaTime * 2.0f);
@@ -44,8 +47,18 @@ public class IntervalIteratingTest {
 		}
 
 		@Override
+		public void startProcessing() {
+			numStartProcessing++;
+		}
+
+		@Override
 		protected void processEntity (Entity entity) {
 			im.get(entity).numUpdates++;
+		}
+
+		@Override
+		public void endProcessing() {
+			numEndProcessing++;
 		}
 	}
 
@@ -71,5 +84,22 @@ public class IntervalIteratingTest {
 				assertEquals(i / 2, im.get(entities.get(j)).numUpdates);
 			}
 		}
+	}
+
+	@Test
+	public void processingUtilityFunctions() {
+		final Engine engine = new Engine();
+
+		final IntervalIteratingSystemSpy system = new IntervalIteratingSystemSpy();
+
+		engine.addSystem(system);
+
+		engine.update(deltaTime);
+		assertEquals(0, system.numStartProcessing);
+		assertEquals(0, system.numEndProcessing);
+
+		engine.update(deltaTime);
+		assertEquals(1, system.numStartProcessing);
+		assertEquals(1, system.numEndProcessing);
 	}
 }

--- a/ashley/tests/com/badlogic/ashley/systems/IteratingSystemTest.java
+++ b/ashley/tests/com/badlogic/ashley/systems/IteratingSystemTest.java
@@ -42,14 +42,26 @@ public class IteratingSystemTest {
 
 	private static class IteratingSystemMock extends IteratingSystem {
 		public int numUpdates;
+		public int numStartProcessing;
+		public int numEndProcessing;
 
 		public IteratingSystemMock (Family family) {
 			super(family);
 		}
 
 		@Override
+		public void startProcessing() {
+			++numStartProcessing;
+		}
+
+		@Override
 		public void processEntity (Entity entity, float deltaTime) {
 			++numUpdates;
+		}
+
+		@Override
+		public void endProcessing() {
+			++numEndProcessing;
 		}
 	}
 
@@ -220,4 +232,22 @@ public class IteratingSystemTest {
 			assertEquals(1, sm.get(e).updates);
 		}
 	}
+
+	@Test
+	public void processingUtilityFunctions() {
+		final Engine engine = new Engine();
+
+		final IteratingSystemMock system = new IteratingSystemMock(Family.all().get());
+
+		engine.addSystem(system);
+
+		engine.update(deltaTime);
+		assertEquals(1, system.numStartProcessing);
+		assertEquals(1, system.numEndProcessing);
+
+		engine.update(deltaTime);
+		assertEquals(2, system.numStartProcessing);
+		assertEquals(2, system.numEndProcessing);
+	}
+
 }

--- a/ashley/tests/com/badlogic/ashley/systems/SortedIteratingSystemTest.java
+++ b/ashley/tests/com/badlogic/ashley/systems/SortedIteratingSystemTest.java
@@ -42,6 +42,8 @@ public class SortedIteratingSystemTest {
 
 	private static class SortedIteratingSystemMock extends SortedIteratingSystem {
 		public LinkedList<String> expectedNames = new LinkedList<String>();
+		public int numStartProcessing;
+		public int numEndProcessing;
 
 		public SortedIteratingSystemMock (Family family) {
 			super(family, comparator);
@@ -54,11 +56,21 @@ public class SortedIteratingSystemTest {
 		}
 
 		@Override
+		public void startProcessing() {
+			++numStartProcessing;
+		}
+
+		@Override
 		public void processEntity (Entity entity, float deltaTime) {
 			OrderComponent component = orderMapper.get(entity);
 			assertNotNull(component);
 			assertFalse(expectedNames.isEmpty());
 			assertEquals(expectedNames.poll(), component.name);
+		}
+
+		@Override
+		public void endProcessing() {
+			++numEndProcessing;
 		}
 	}
 
@@ -280,6 +292,23 @@ public class SortedIteratingSystemTest {
 		system.expectedNames.addLast("B");
 		system.expectedNames.addLast("A");
 		engine.update(0);
+	}
+
+	@Test
+	public void processingUtilityFunctions() {
+		final Engine engine = new Engine();
+
+		final SortedIteratingSystemMock system = new SortedIteratingSystemMock(Family.all().get());
+
+		engine.addSystem(system);
+
+		engine.update(deltaTime);
+		assertEquals(1, system.numStartProcessing);
+		assertEquals(1, system.numEndProcessing);
+
+		engine.update(deltaTime);
+		assertEquals(2, system.numStartProcessing);
+		assertEquals(2, system.numEndProcessing);
 	}
 
 	private static class OrderComparator implements Comparator<Entity> {

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: "java"
-sourceCompatibility = 1.6
+sourceCompatibility = 1.7
 
 eclipse.project {
     name = "ecs-benchmarks"

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ subprojects {
 
 ext {
     projectGroup = "ashley"
-    gdxVersion = "1.10.0"
+    gdxVersion = "1.9.8"
     jUnitVersion = "4.12"
     mockitoVersion = "1.10.19"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ subprojects {
 
 ext {
     projectGroup = "ashley"
-    gdxVersion = "1.9.9"
+    gdxVersion = "1.10.0"
     jUnitVersion = "4.12"
     mockitoVersion = "1.10.19"
 }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: "java"
-sourceCompatibility = 1.6
+sourceCompatibility = 1.7
 
 sourceSets.main.java.srcDirs = [ "src/" ]
 sourceSets.main.resources.srcDirs = [ "src/" ]


### PR DESCRIPTION
Updating to the newest libGDX version, through the update to Gradle 4.3 java source compatibility 1.6 is no longer supported, so updated to version 1.7 (which is also deprecated and should be updated to 1.8 in the near future)

Fix libGDX capitalization in the readme, as the official libGDX repo did it

Created small utility functions in the iterating systems to enable the efficient usage of iterating systems for render systems and such: 

Example Implementation of a Render System:

```
public class RenderSystem extends IteratingSystem {

	private SpriteBatch batch;
	private OrthographicCamera camera;

	private ComponentMapper<PositionComponent> pm = ComponentMapper.getFor(PositionComponent.class);
	private ComponentMapper<VisualComponent> vm = ComponentMapper.getFor(VisualComponent.class);

	public RenderSystem (OrthographicCamera camera) {
		super(Family.all(PositionComponent.class, VisualComponent.class).get());
		batch = new SpriteBatch();
		this.camera = camera;
	}

	@Override
	public void startProcessing() {
		camera.update();

		batch.setProjectionMatrix(camera.combined);
		batch.begin();
	}

	@Override
	protected void processEntity(Entity entity, float deltaTime) {
		PositionComponent position = pm.get(entity);
		VisualComponent visual = vm.get(entity);

		batch.draw(visual.region, position.x, position.y);
	}

	@Override
	public void endProcessing() {
		batch.end();
	}
}
```