### PR TITLE
Ensure Components are returned to the ComponentPools instance if it is not full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### Ashley 1.7.4
+
+* **Bug fix**: Poolable Component returned to their ComponentPools even if EntityPool is full. Issue #302.
+* **Update**: Uses libgdx 1.10.0. Commit afa68fc165119a2c79c1709c642e6b620a973ecc.
+
 ### Ashley 1.7.3
 
 * **API addition***: Adds 'createComponent()' method to `Engine` class. Commit 07fc2ba6bcd9996c472c651b56b57b32fd8fd3a7.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## Changelog
 
-### Ashley 1.7.4
+### Ashley 1.8.0
 
 * **Bug fix**: Poolable Component returned to their ComponentPools even if EntityPool is full. Issue #302.
 * **Update**: Uses libgdx 1.10.0. Commit afa68fc165119a2c79c1709c642e6b620a973ecc.
+
+### Ashley 1.7.4
 
 ### Ashley 1.7.3
 

--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -126,6 +126,15 @@ public class PooledEngine extends Engine {
 		protected PooledEntity newObject () {
 			return new PooledEntity();
 		}
+
+		/**
+		 * Forwarding this call ensures {@link Poolable} {@link Component} instances are returned to their respective
+		 * {@link ComponentPools}s even if the {@link EntityPool} is full.
+		 */
+		@Override
+		protected void discard(PooledEntity pooledEntity) {
+			pooledEntity.reset();
+		}
 	}
 
 	private class ComponentPools {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ subprojects {
 
 ext {
     projectGroup = "ashley"
-    gdxVersion = "1.9.8"
+    gdxVersion = "1.10.0"
     jUnitVersion = "4.12"
     mockitoVersion = "1.10.19"
 }


### PR DESCRIPTION
- LibGDX version increased to 1.10.0
- PooledEntity instances are reset regardless of if they are being returned to the EntityPool or not (fixes #302)