### PR TITLE
Poolable Component instances always have their reset() method called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * **Bug fix**: Poolable Component returned to their ComponentPools even if EntityPool is full. Issue #302.
 * **Update**: Uses libgdx 1.10.0. Commit afa68fc165119a2c79c1709c642e6b620a973ecc.
 * **Bug fix**: Poolable Component instances always have their reset() method called, even if their ComponentPool is full.
+* **Internals**: ComponentPool expects Components to be instances of Component.
 
 ### Ashley 1.7.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * **Bug fix**: Poolable Component returned to their ComponentPools even if EntityPool is full. Issue #302.
 * **Update**: Uses libgdx 1.10.0. Commit afa68fc165119a2c79c1709c642e6b620a973ecc.
+* **Bug fix**: Poolable Component instances always have their reset() method called, even if their ComponentPool is full.
 
 ### Ashley 1.7.4
 


### PR DESCRIPTION
This is an extension of PR #303, ensuring Poolable Component instances have reset() called on them regardless of if their respective Pools are full. The previous PR handled the case where if the EntityPool was full no Components would be reset(), this PR covers the case where if individual ComponentPools are full the Components are not being reset().