### PR TITLE
added breaking unit test case and fix for issue #306

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/EntityManager.java
+++ b/ashley/src/com/badlogic/ashley/core/EntityManager.java
@@ -23,6 +23,7 @@ class EntityManager {
 	}
 	
 	public void addEntity(Entity entity, boolean delayed){
+		entity.scheduledForRemoval = false;
 		if (delayed) {
 			EntityOperation operation = entityOperationPool.obtain();
 			operation.entity = entity;

--- a/ashley/tests/com/badlogic/ashley/core/EngineTests.java
+++ b/ashley/tests/com/badlogic/ashley/core/EngineTests.java
@@ -972,4 +972,24 @@ public class EngineTests {
 		ComponentC componentC = engine.createComponent(ComponentC.class);
 		assertNull(componentC);
 	}
+
+	public class RemoveAddAndRemoveEntitySystem extends EntitySystem {
+
+		@Override
+		public void update(float deltaTime) {
+			Entity entity = new Entity();
+			getEngine().removeEntity(entity);
+			getEngine().addEntity(entity);
+			getEngine().removeEntity(entity);
+		}
+	}
+
+	@Test
+	public void removeEntityBeforeAddingAndWhileEngineIsUpdating() {
+		// Test for issue #306.
+		Engine engine = new Engine();
+		engine.addSystem(new RemoveAddAndRemoveEntitySystem());
+		engine.update(deltaTime);
+		assertEquals(0, engine.getEntities().size());
+	}
 }


### PR DESCRIPTION
Closes #306.

To fix the issue, we set `entity.scheduledForRemoval` to false whenever an entity is added.