### PR TITLE
Added getters for the free objects in the pooled engine.

### DIFF
--- a/ashley/src/com/badlogic/ashley/core/PooledEngine.java
+++ b/ashley/src/com/badlogic/ashley/core/PooledEngine.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
  * Copyright 2014 See AUTHORS file.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -83,6 +83,20 @@ public class PooledEngine extends Engine {
 	public void clearPools () {
 		entityPool.clear();
 		componentPools.clear();
+	}
+
+	/**
+	 * @return Number of free objects in the entity pool.
+	 */
+	public int getEntityPoolFree( ) {
+		return entityPool.getFree();
+	}
+
+	/**
+	 * @return Number of free objects in the given component type pool.
+	 */
+	public <T extends Component> int getComponentPoolFree(Class<T> componentType) {
+		return componentPools.pools.get(componentType).getFree();
 	}
 
 	@Override


### PR DESCRIPTION
Hello,
I want in my game to monitor the number of free objects in the pools - this is to make sure I don't have cases where calling "free()" is missed and thus leading to creating limitlessly new objects. I also wanted to monitor on the components and entities, but found out there's no access to the pools themseleves. So I added 2 getters.

Thanks in advance!